### PR TITLE
Legg til komponent: Ting jeg eier

### DIFF
--- a/src/features/oversikt/Eiendeler/EiendelerKomponent.jsx
+++ b/src/features/oversikt/Eiendeler/EiendelerKomponent.jsx
@@ -1,0 +1,60 @@
+import { Heading1, Heading6, Paragraph } from "@sb1/ffe-core-react";
+import { formatCurrency } from "@sb1/ffe-formatters";
+import "./eiendeler.css";
+import HusIkon from "@sb1/ffe-icons-react/lib/hus-ikon";
+import CampingvognIkon from "@sb1/ffe-icons-react/lib/campingvogn-ikon";
+import MopedIkon from "@sb1/ffe-icons-react/lib/moped-ikon";
+import ChevronIkon from "@sb1/ffe-icons-react/lib/chevron-ikon";
+
+const EiendelerKomponent = () => {
+  return (
+    <div className="ting-jeg-eier-komponent">
+      <Heading1>Ting jeg eier</Heading1>
+
+      <ul className="eiendeler-liste">
+        <li>
+          <div className="eiendel-kort">
+            <CampingvognIkon className="eiendel-kort__ikon" />
+            <div className="eiendel-kort__innhold">
+              <Heading6 className="eiendel-kort__heading ffe-h6">
+                Campingvogn
+              </Heading6>
+              <Paragraph className="eiendel-kort__sub-heading">
+                {formatCurrency(30000, { prefix: "", postfix: " kr" })}
+              </Paragraph>
+            </div>
+            <ChevronIkon className="eiendel-kort__chevron" />
+          </div>
+        </li>
+        <li>
+          <div className="eiendel-kort">
+            <HusIkon className="eiendel-kort__ikon" />
+            <div className="eiendel-kort__innhold">
+              <Heading6 className="eiendel-kort__heading ffe-h6">Hus</Heading6>
+              <Paragraph className="eiendel-kort__sub-heading">
+                {formatCurrency(2500000, { prefix: "", postfix: " kr" })}
+              </Paragraph>
+            </div>
+            <ChevronIkon className="eiendel-kort__chevron" />
+          </div>
+        </li>
+        <li>
+          <div className="eiendel-kort">
+            <MopedIkon className="eiendel-kort__ikon" />
+            <div className="eiendel-kort__innhold">
+              <Heading6 className="eiendel-kort__heading ffe-h6">
+                Scooter
+              </Heading6>
+              <Paragraph className="eiendel-kort__sub-heading">
+                {formatCurrency(18000, { prefix: "", postfix: " kr" })}
+              </Paragraph>
+            </div>
+            <ChevronIkon className="eiendel-kort__chevron" />
+          </div>
+        </li>
+      </ul>
+    </div>
+  );
+};
+
+export default EiendelerKomponent;

--- a/src/features/oversikt/Eiendeler/eiendeler.css
+++ b/src/features/oversikt/Eiendeler/eiendeler.css
@@ -1,0 +1,56 @@
+.eiendeler-liste {
+  background-color: #fff;
+  border-radius: 1rem;
+  box-shadow: 0 0.0625rem 0.25rem #e5dfdb;
+  list-style-type: none;
+  padding: 0;
+  width: 400px;
+  margin: 0 auto;
+}
+
+li {
+  border-bottom: lightgrey 1px solid;
+}
+li:first-child {
+  border-top-left-radius: 1rem;
+  border-top-right-radius: 1rem;
+}
+
+li:last-child {
+  border-bottom-left-radius: 1rem;
+  border-bottom-right-radius: 1rem;
+  border-bottom: none;
+}
+
+.eiendel-kort {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  min-height: 5rem;
+  padding: 0.625rem 1rem;
+  position: relative;
+}
+
+.eiendel-kort__ikon {
+  height: 40px;
+  fill: #002776;
+}
+
+.eiendel-kort__innhold {
+  display: flex;
+  flex-direction: column;
+  text-align: left;
+  min-width: 250px;
+}
+
+.eiendel-kort__heading {
+  margin-top: 1em;
+  margin-bottom: 0;
+}
+
+.eiendel-kort__chevron {
+  height: 15px;
+  fill: #002776;
+  transform: rotate(270deg);
+}

--- a/src/features/oversikt/Oversikt.jsx
+++ b/src/features/oversikt/Oversikt.jsx
@@ -4,11 +4,13 @@ import { ImageCard } from "@sb1/ffe-cards-react";
 import atv from "./bilder/ATV.png";
 import sparegris from "./bilder/Sparegris.png";
 import "./style.css";
+import EiendelerKomponent from "./Eiendeler/EiendelerKomponent.jsx";
 
 export const Oversikt = () => {
   return (
     <>
       <Heading1 className="App-heading">Min oversikt</Heading1>
+      <EiendelerKomponent />
       <Grid className="">
         <GridRow className="oversikt-kort-container">
           <GridCol sm={4}>


### PR DESCRIPTION
La til "Ting jeg eier"-komponenten. 
Usikker på hva som skal skje om man trykker på elementene i listen, så nå er de ikke klikkbare.
Har kun gjort styling i komponenten, har ikke sett på plasering innad på oversiktsiden.
Var usikker på om det er best å hardkode inn listeelementene slik det er nå som kanskje er mer lesbart om man ikke er så dreven på web. Eller mappe over en liste av eiendeler for å vise n-antall rader som er mer standard måte å gjøre det på men kanskje mindre lesbart. :thinking: 

Ser slik ut:
![image](https://github.com/sparebank1utvikling/girl-tech-tenk-ws/assets/6331302/bb6e171e-c2be-44ed-8377-1376c85d8ffe)

