### PR TITLE
remove text-align:center from App and make Send a bit more like nettbank

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@sb1/ffe-icons-react": "^7.3.5",
         "@sb1/ffe-message-box": "^11.0.4",
         "@sb1/ffe-message-box-react": "^8.0.7",
-        "@sb1/ffe-searchable-dropdown-react": "^15.1.6",
+        "@sb1/ffe-searchable-dropdown-react": "^15.2.3",
         "@sb1/ffe-spinner": "^5.0.4",
         "@sb1/ffe-spinner-react": "^6.0.5",
         "@sb1/ffe-tabs": "^13.0.3",
@@ -1244,13 +1244,13 @@
       }
     },
     "node_modules/@sb1/ffe-searchable-dropdown-react": {
-      "version": "15.1.6",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-searchable-dropdown-react/-/ffe-searchable-dropdown-react-15.1.6.tgz",
-      "integrity": "sha512-mOWkvjHmlefcKEki9OeFM8is+c+MnVHBG6DUyGYdBB3P9mPmkchxMW3vDbCywpz9KT6Q19MdAWN/rEzUwqt1gQ==",
+      "version": "15.2.3",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-searchable-dropdown-react/-/ffe-searchable-dropdown-react-15.2.3.tgz",
+      "integrity": "sha512-GzJKsO3Hc3vgBdSJeEq2h8ynS4HqYYezd0xCq1tKWwf3Xb/3cWBd5VJX+XcPra7IN8koTMUXoybw3aLTUgwwJA==",
       "license": "MIT",
       "dependencies": {
         "@sb1/ffe-core-react": "^7.1.1",
-        "@sb1/ffe-form": "^23.0.7",
+        "@sb1/ffe-form": "^24.0.1",
         "@sb1/ffe-icons-react": "^7.3.5",
         "@sb1/ffe-spinner-react": "^6.0.5",
         "classnames": "^2.3.1",
@@ -1263,6 +1263,16 @@
       },
       "peerDependencies": {
         "react": ">=16.9.0"
+      }
+    },
+    "node_modules/@sb1/ffe-searchable-dropdown-react/node_modules/@sb1/ffe-form": {
+      "version": "24.0.1",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-form/-/ffe-form-24.0.1.tgz",
+      "integrity": "sha512-9lo51Dnfj1iOxjFTzWmIPhHRW1aFRqYBfXyBgX2Tf9I3NkmDt1L71U7UVROOxjSz481nQjZVzqAfzicj934eCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sb1/ffe-buttons": "^17.0.3",
+        "@sb1/ffe-core": "^27.0.1"
       }
     },
     "node_modules/@sb1/ffe-spinner": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@sb1/ffe-icons-react": "^7.3.5",
     "@sb1/ffe-message-box": "^11.0.4",
     "@sb1/ffe-message-box-react": "^8.0.7",
-    "@sb1/ffe-searchable-dropdown-react": "^15.1.6",
+    "@sb1/ffe-searchable-dropdown-react": "^15.2.3",
     "@sb1/ffe-spinner": "^5.0.4",
     "@sb1/ffe-spinner-react": "^6.0.5",
     "@sb1/ffe-tabs": "^13.0.3",

--- a/src/App.less
+++ b/src/App.less
@@ -3,7 +3,6 @@
 @import (inline) "@sb1/ffe-webfonts/sb1-fonts.css";
 @import "@sb1/ffe-cards/less/cards";
 @import "@sb1/ffe-account-selector-react/less/ffe-account-selector";
-@import "@sb1/ffe-account-selector-react/less/base-selector";
 @import "@sb1/ffe-datepicker/less/datepicker";
 @import "@sb1/ffe-searchable-dropdown-react/less/searchable-dropdown";
 @import "@sb1/ffe-form/less/form";
@@ -14,7 +13,6 @@
 @import "@sb1/ffe-tabs/less/tabs";
 
 .App {
-  text-align: center;
   background-color: @ffe-farge-sand-30;
   min-height: 100vh;
 }
@@ -47,6 +45,7 @@
 }
 
 .Navbar {
+  text-align: center;
   background-color: #fff;
 }
 

--- a/src/features/oversikt/Eiendeler/EiendelerKomponent.jsx
+++ b/src/features/oversikt/Eiendeler/EiendelerKomponent.jsx
@@ -9,8 +9,7 @@ import ChevronIkon from "@sb1/ffe-icons-react/lib/chevron-ikon";
 const EiendelerKomponent = () => {
   return (
     <div className="ting-jeg-eier-komponent">
-      <Heading1>Ting jeg eier</Heading1>
-
+      <Heading1 className="eiendeler-heading">Ting jeg eier</Heading1>
       <ul className="eiendeler-liste">
         <li>
           <div className="eiendel-kort">

--- a/src/features/oversikt/Eiendeler/eiendeler.css
+++ b/src/features/oversikt/Eiendeler/eiendeler.css
@@ -1,3 +1,7 @@
+.eiendeler-heading {
+  text-align: center;
+}
+
 .eiendeler-liste {
   background-color: #fff;
   border-radius: 1rem;
@@ -11,6 +15,7 @@
 .eiendeler-liste li {
   border-bottom: lightgrey 1px solid;
 }
+
 .eiendeler-liste li:first-child {
   border-top-left-radius: 1rem;
   border-top-right-radius: 1rem;
@@ -40,7 +45,6 @@
 .eiendel-kort__innhold {
   display: flex;
   flex-direction: column;
-  text-align: left;
   min-width: 250px;
 }
 

--- a/src/features/send/NedtrekkListeKomponent.jsx
+++ b/src/features/send/NedtrekkListeKomponent.jsx
@@ -4,12 +4,19 @@ import PropTypes from "prop-types";
 import "./SendStyle.css";
 import { AccountSelector } from "@sb1/ffe-account-selector-react";
 
-const NedtrekkListeKomponent = ({ label, dropdownList, inputProps }) => {
+const NedtrekkListeKomponent = ({
+  label,
+  dropdownList,
+  inputProps,
+  showBalance,
+  id,
+}) => {
   const [selectedOption, setSelectedOption] = useState(null);
 
   return (
     <InputGroup label={label} className="elementContainer">
       <AccountSelector
+        id={id}
         accounts={dropdownList}
         locale="nb"
         onAccountSelected={(val) => setSelectedOption(val)}
@@ -18,6 +25,7 @@ const NedtrekkListeKomponent = ({ label, dropdownList, inputProps }) => {
         ariaInvalid={false}
         inputProps={inputProps}
         className="searchableDropDown"
+        showBalance={showBalance}
       />
     </InputGroup>
   );
@@ -27,6 +35,8 @@ NedtrekkListeKomponent.propTypes = {
   label: PropTypes.string.isRequired,
   inputProps: PropTypes.string.isRequired,
   dropdownList: PropTypes.array.isRequired,
+  showBalance: PropTypes.bool.isRequired,
+  id: PropTypes.string.isRequired,
 };
 
 export default NedtrekkListeKomponent;

--- a/src/features/send/Send.jsx
+++ b/src/features/send/Send.jsx
@@ -17,18 +17,39 @@ const Send = () => {
   const handleSendClick = () => {
     setShowSuccessMessage(true);
   };
-  const transferMoneyList = [
+  const myAccounts = [
     {
-      name: "Min konto",
+      name: "Min brukskonto",
+      accountNumber: "2234 56 789102",
+      currencyCode: "NOK",
+      balance: 300,
+    },
+    {
+      name: "Sparekonto",
+      accountNumber: "1234 56 789101",
+      currencyCode: "NOK",
+      balance: 90000,
+    },
+    {
+      name: "Mikrospar",
+      accountNumber: "1234 56 789102",
+      currencyCode: "NOK",
+      balance: 5000,
+    },
+  ];
+
+  const myPaymentRecipients = [
+    {
+      name: "Min brukskonto",
       accountNumber: "2234 56 789102",
     },
     {
       name: "Mamma",
-      accountNumber: "1234 56 789101",
+      accountNumber: "1234 56 789103",
     },
     {
       name: "Pappa",
-      accountNumber: "1234 56 789102",
+      accountNumber: "1234 56 789143",
     },
   ];
 
@@ -45,15 +66,18 @@ const Send = () => {
           <NedtrekkListeKomponent
             label={"Fra"}
             inputProps={{ placeholder: "Velg konto" }}
-            dropdownList={transferMoneyList}
+            dropdownList={myAccounts}
+            showBalance={true}
+            id="fra-konto"
           />
           <NedtrekkListeKomponent
             label={"Til"}
             inputProps={{ placeholder: "Fyll inn kontonummer eller navn" }}
-            dropdownList={transferMoneyList}
+            dropdownList={myPaymentRecipients}
+            showBalance={false}
+            id="mottaker"
           />
           <TextInput label={"Beløp"} placeholder={"0,00 kr"} />
-
           <Datepicker
             inputProps={{ id: "datepicker--block" }}
             label="Velg dato"


### PR DESCRIPTION
text-align:center for hele appen førte til at forslagene i kontovelger så litt rare ut, så har tatt den vekk. 
Har også delt opp kontolistene for fra og til på Send-siden. La også til saldo på fra-kontoene, siden jeg syns å huske at det ble nevnt at deltagerne syns det var gøy å endre saldoen sin i fjor :moneybag: 

Ny fra-liste: 
![image](https://github.com/sparebank1utvikling/girl-tech-tenk-ws/assets/6331302/7b1d6b5c-5c80-4e5c-8cf1-61080ed06d3f)