### PR TITLE
Bump dependencies and remove workaround for react-virtualization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,25 +8,25 @@
       "name": "girl-tech-tenk-ws",
       "version": "0.0.0",
       "dependencies": {
-        "@sb1/ffe-account-selector-react": "^21.3.6",
+        "@sb1/ffe-account-selector-react": "^22.1.0",
         "@sb1/ffe-buttons": "^17.0.3",
         "@sb1/ffe-buttons-react": "^18.0.2",
-        "@sb1/ffe-cards": "^15.0.3",
-        "@sb1/ffe-cards-react": "^11.0.2",
+        "@sb1/ffe-cards": "^16.2.0",
+        "@sb1/ffe-cards-react": "^12.1.2",
         "@sb1/ffe-chart-donut-react": "^5.2.0",
         "@sb1/ffe-core": "^27.0.1",
         "@sb1/ffe-core-react": "^7.1.1",
         "@sb1/ffe-datepicker": "^11.0.9",
         "@sb1/ffe-datepicker-react": "^6.0.10",
-        "@sb1/ffe-form": "^23.0.7",
-        "@sb1/ffe-form-react": "^11.0.10",
+        "@sb1/ffe-form": "^24.1.0",
+        "@sb1/ffe-form-react": "^13.0.3",
         "@sb1/ffe-formatters": "^4.0.11",
         "@sb1/ffe-grid-react": "^13.0.5",
         "@sb1/ffe-header": "^19.0.2",
         "@sb1/ffe-icons-react": "^7.3.5",
         "@sb1/ffe-message-box": "^11.0.4",
-        "@sb1/ffe-message-box-react": "^8.0.7",
-        "@sb1/ffe-searchable-dropdown-react": "^15.2.3",
+        "@sb1/ffe-message-box-react": "^9.0.3",
+        "@sb1/ffe-searchable-dropdown-react": "^16.1.0",
         "@sb1/ffe-spinner": "^5.0.4",
         "@sb1/ffe-spinner-react": "^6.0.5",
         "@sb1/ffe-tabs": "^13.0.3",
@@ -37,7 +37,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.11.2",
-        "vite-plugin-svgr": "^3.2.0"
+        "vite-plugin-svgr": "^4.0.0"
       },
       "devDependencies": {
         "@types/react": "^18.0.37",
@@ -46,11 +46,19 @@
         "eslint": "^8.38.0",
         "eslint-plugin-react": "^7.32.2",
         "eslint-plugin-react-hooks": "^4.6.0",
-        "eslint-plugin-react-refresh": "^0.3.4",
-        "fs": "^0.0.1-security",
-        "path": "^0.12.7",
-        "prettier": "^2.8.8",
+        "eslint-plugin-react-refresh": "^0.4.3",
+        "prettier": "^3.0.3",
         "vite": "^4.3.9"
+      }
+    },
+    "node_modules/@aashutoshrathi/word-wrap": {
+      "version": "1.2.6",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
+      "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -67,47 +75,48 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.21.4",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/code-frame/-/code-frame-7.21.4.tgz",
-      "integrity": "sha512-LYvhNKfwWSPpocw8GI7gpK2nq3HSDuEPC/uSYaALSJu9xjsalaaYFOq0Pwt5KmVqwEbZlDu81aLXwBOmD/Fv9g==",
+      "version": "7.22.13",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/code-frame/-/code-frame-7.22.13.tgz",
+      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
       "license": "MIT",
       "dependencies": {
-        "@babel/highlight": "^7.18.6"
+        "@babel/highlight": "^7.22.13",
+        "chalk": "^2.4.2"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.22.3",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/compat-data/-/compat-data-7.22.3.tgz",
-      "integrity": "sha512-aNtko9OPOwVESUFp3MZfD8Uzxl7JzSeJpd7npIoxCasU37PFbAQRpKglkaKwlHOyeJdrREpo8TW8ldrkYWwvIQ==",
+      "version": "7.22.20",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/compat-data/-/compat-data-7.22.20.tgz",
+      "integrity": "sha512-BQYjKbpXjoXwFW5jGqiizJQQT/aC7pFm9Ok1OWssonuguICi264lbgMzRp2ZMmRSlfkX6DsWDDcsrctK8Rwfiw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.22.1",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/core/-/core-7.22.1.tgz",
-      "integrity": "sha512-Hkqu7J4ynysSXxmAahpN1jjRwVJ+NdpraFLIWflgjpVob3KNyK3/tIUc7Q7szed8WMp0JNa7Qtd1E9Oo22F9gA==",
+      "version": "7.23.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/core/-/core-7.23.0.tgz",
+      "integrity": "sha512-97z/ju/Jy1rZmDxybphrBuI+jtJjFVoz7Mr9yUQVVVi+DNZE333uFQeMOqcCIy1x3WYBIbWftUSLmbNXNT7qFQ==",
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.21.4",
-        "@babel/generator": "^7.22.0",
-        "@babel/helper-compilation-targets": "^7.22.1",
-        "@babel/helper-module-transforms": "^7.22.1",
-        "@babel/helpers": "^7.22.0",
-        "@babel/parser": "^7.22.0",
-        "@babel/template": "^7.21.9",
-        "@babel/traverse": "^7.22.1",
-        "@babel/types": "^7.22.0",
-        "convert-source-map": "^1.7.0",
+        "@babel/code-frame": "^7.22.13",
+        "@babel/generator": "^7.23.0",
+        "@babel/helper-compilation-targets": "^7.22.15",
+        "@babel/helper-module-transforms": "^7.23.0",
+        "@babel/helpers": "^7.23.0",
+        "@babel/parser": "^7.23.0",
+        "@babel/template": "^7.22.15",
+        "@babel/traverse": "^7.23.0",
+        "@babel/types": "^7.23.0",
+        "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.2",
-        "semver": "^6.3.0"
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -118,12 +127,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.22.3",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/generator/-/generator-7.22.3.tgz",
-      "integrity": "sha512-C17MW4wlk//ES/CJDL51kPNwl+qiBQyN7b9SKyVp11BLGFeSPoVaHrv+MNt8jwQFhQWowW88z1eeBx3pFz9v8A==",
+      "version": "7.23.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/generator/-/generator-7.23.0.tgz",
+      "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.22.3",
+        "@babel/types": "^7.23.0",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -133,16 +142,78 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.22.1",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.1.tgz",
-      "integrity": "sha512-Rqx13UM3yVB5q0D/KwQ8+SPfX/+Rnsy1Lw1k/UwOC4KC6qrzIQoY3lYnBu5EHKBlEHHcj0M0W8ltPSkD8rqfsQ==",
+      "version": "7.22.15",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.15.tgz",
+      "integrity": "sha512-y6EEzULok0Qvz8yyLkCvVX+02ic+By2UdOhylwUOvOn9dvYc9mKICJuuU1n1XBI02YWsNsnrY1kc6DVbjcXbtw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.22.0",
-        "@babel/helper-validator-option": "^7.21.0",
-        "browserslist": "^4.21.3",
+        "@babel/compat-data": "^7.22.9",
+        "@babel/helper-validator-option": "^7.22.15",
+        "browserslist": "^4.21.9",
         "lru-cache": "^5.1.1",
-        "semver": "^6.3.0"
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-environment-visitor": {
+      "version": "7.22.20",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-function-name": {
+      "version": "7.23.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+      "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.22.15",
+        "@babel/types": "^7.23.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-hoist-variables": {
+      "version": "7.22.5",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
+      "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.22.15",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
+      "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.22.15"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.23.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/helper-module-transforms/-/helper-module-transforms-7.23.0.tgz",
+      "integrity": "sha512-WhDWw1tdrlT0gMgUJSlX0IQvoO1eN279zrAUbVB+KpV2c3Tylz8+GnKOLllCS6Z/iZQEyVYxhZVUdPTqs2YYPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-module-imports": "^7.22.15",
+        "@babel/helper-simple-access": "^7.22.5",
+        "@babel/helper-split-export-declaration": "^7.22.6",
+        "@babel/helper-validator-identifier": "^7.22.20"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -151,75 +222,10 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.22.1",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.1.tgz",
-      "integrity": "sha512-Z2tgopurB/kTbidvzeBrc2To3PUP/9i5MUe+fU6QJCQDyPwSH2oRapkLw3KGECDYSjhQZCNxEvNvZlLw8JjGwA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-function-name": {
-      "version": "7.21.0",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/helper-function-name/-/helper-function-name-7.21.0.tgz",
-      "integrity": "sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/template": "^7.20.7",
-        "@babel/types": "^7.21.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.18.6",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
-      "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.18.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-imports": {
-      "version": "7.21.4",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/helper-module-imports/-/helper-module-imports-7.21.4.tgz",
-      "integrity": "sha512-orajc5T2PsRYUN3ZryCEFeMDYwyw09c/pZeaQEZPH0MpKzSvn3e0uXsDBu3k03VI+9DBiRo+l22BfKTpKwa/Wg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.21.4"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-transforms": {
-      "version": "7.22.1",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/helper-module-transforms/-/helper-module-transforms-7.22.1.tgz",
-      "integrity": "sha512-dxAe9E7ySDGbQdCVOY/4+UcD8M9ZFqZcZhSPsPacvCG4M+9lwtDDQfI2EoaSvmf7W/8yCBkGU0m7Pvt1ru3UZw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-environment-visitor": "^7.22.1",
-        "@babel/helper-module-imports": "^7.21.4",
-        "@babel/helper-simple-access": "^7.21.5",
-        "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/helper-validator-identifier": "^7.19.1",
-        "@babel/template": "^7.21.9",
-        "@babel/traverse": "^7.22.1",
-        "@babel/types": "^7.22.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.21.5",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/helper-plugin-utils/-/helper-plugin-utils-7.21.5.tgz",
-      "integrity": "sha512-0WDaIlXKOX/3KfBK/dwP1oQGiPh6rjMkT7HIRv7i5RR2VUMwrx5ZL0dwBkKx7+SW1zwNdgjHd34IMk5ZjTeHVg==",
+      "version": "7.22.5",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
+      "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -227,78 +233,78 @@
       }
     },
     "node_modules/@babel/helper-simple-access": {
-      "version": "7.21.5",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/helper-simple-access/-/helper-simple-access-7.21.5.tgz",
-      "integrity": "sha512-ENPDAMC1wAjR0uaCUwliBdiSl1KBJAVnMTzXqi64c2MG8MPR6ii4qf7bSXDqSFbr4W6W028/rf5ivoHop5/mkg==",
+      "version": "7.22.5",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
+      "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.21.5"
+        "@babel/types": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.18.6",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
-      "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
+      "version": "7.22.6",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
+      "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.18.6"
+        "@babel/types": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.21.5",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/helper-string-parser/-/helper-string-parser-7.21.5.tgz",
-      "integrity": "sha512-5pTUx3hAJaZIdW99sJ6ZUUgWq/Y+Hja7TowEnLNMm1VivRgZQL3vpBY3qUACVsvw+yQU6+YgfBVmcbLaZtrA1w==",
+      "version": "7.22.5",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
+      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.19.1",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
-      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
+      "version": "7.22.20",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.21.0",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/helper-validator-option/-/helper-validator-option-7.21.0.tgz",
-      "integrity": "sha512-rmL/B8/f0mKS2baE9ZpyTcTavvEuWhTTW8amjzXNvYG4AwBsqTLikfXsEofsJEfKHf+HQVQbFOHy6o+4cnC/fQ==",
+      "version": "7.22.15",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/helper-validator-option/-/helper-validator-option-7.22.15.tgz",
+      "integrity": "sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.22.3",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/helpers/-/helpers-7.22.3.tgz",
-      "integrity": "sha512-jBJ7jWblbgr7r6wYZHMdIqKc73ycaTcCaWRq4/2LpuPHcx7xMlZvpGQkOYc9HeSjn6rcx15CPlgVcBtZ4WZJ2w==",
+      "version": "7.23.1",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/helpers/-/helpers-7.23.1.tgz",
+      "integrity": "sha512-chNpneuK18yW5Oxsr+t553UZzzAs3aZnFm4bxhebsNTeshrC95yA7l5yl7GBAG+JG1rF0F7zzD2EixK9mWSDoA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.21.9",
-        "@babel/traverse": "^7.22.1",
-        "@babel/types": "^7.22.3"
+        "@babel/template": "^7.22.15",
+        "@babel/traverse": "^7.23.0",
+        "@babel/types": "^7.23.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.18.6",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/highlight/-/highlight-7.18.6.tgz",
-      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+      "version": "7.22.20",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/highlight/-/highlight-7.22.20.tgz",
+      "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.18.6",
-        "chalk": "^2.0.0",
+        "@babel/helper-validator-identifier": "^7.22.20",
+        "chalk": "^2.4.2",
         "js-tokens": "^4.0.0"
       },
       "engines": {
@@ -306,9 +312,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.22.4",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/parser/-/parser-7.22.4.tgz",
-      "integrity": "sha512-VLLsx06XkEYqBtE5YGPwfSGwfrjnyPP5oiGty3S8pQLFDFLaS8VwWSIxkTXpcvr5zeYLE6+MBNl2npl/YnfofA==",
+      "version": "7.23.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/parser/-/parser-7.23.0.tgz",
+      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
       "license": "MIT",
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -318,13 +324,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx-self": {
-      "version": "7.21.0",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.21.0.tgz",
-      "integrity": "sha512-f/Eq+79JEu+KUANFks9UZCcvydOOGMgF7jBrcwjHa5jTZD8JivnhCJYvmlhR/WTXBWonDExPoW0eO/CR4QJirA==",
+      "version": "7.22.5",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.22.5.tgz",
+      "integrity": "sha512-nTh2ogNUtxbiSbxaT4Ds6aXnXEipHweN9YRgOX/oNXdf0cCrGn/+2LozFa3lnPV5D90MkjhgckCPBrsoSc1a7g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.20.2"
+        "@babel/helper-plugin-utils": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -334,13 +340,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx-source": {
-      "version": "7.19.6",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.19.6.tgz",
-      "integrity": "sha512-RpAi004QyMNisst/pvSanoRdJ4q+jMCWyk9zdw/CyLB9j8RXEahodR6l2GyttDRyEVWZtbN+TpLiHJ3t34LbsQ==",
+      "version": "7.22.5",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.22.5.tgz",
+      "integrity": "sha512-yIiRO6yobeEIaI0RTbIr8iAK9FcBHLtZq0S89ZPjDLQXBA4xvghaKqI0etp/tF3htTM0sazJKKLz9oEiGRtu7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.19.0"
+        "@babel/helper-plugin-utils": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -350,45 +356,45 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.22.3",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/runtime/-/runtime-7.22.3.tgz",
-      "integrity": "sha512-XsDuspWKLUsxwCp6r7EhsExHtYfbe5oAGQ19kqngTdCPUoPQzOPdUbD/pB9PJiwb2ptYKQDjSJT3R6dC+EPqfQ==",
+      "version": "7.23.1",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/runtime/-/runtime-7.23.1.tgz",
+      "integrity": "sha512-hC2v6p8ZSI/W0HUzh3V8C5g+NwSKzKPtJwSpTjwl0o297GP9+ZLQSkdvHz46CM3LqyoXxq+5G9komY+eSqSO0g==",
       "license": "MIT",
       "dependencies": {
-        "regenerator-runtime": "^0.13.11"
+        "regenerator-runtime": "^0.14.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.21.9",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/template/-/template-7.21.9.tgz",
-      "integrity": "sha512-MK0X5k8NKOuWRamiEfc3KEJiHMTkGZNUjzMipqCGDDc6ijRl/B7RGSKVGncu4Ro/HdyzzY6cmoXuKI2Gffk7vQ==",
+      "version": "7.22.15",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/template/-/template-7.22.15.tgz",
+      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.21.4",
-        "@babel/parser": "^7.21.9",
-        "@babel/types": "^7.21.5"
+        "@babel/code-frame": "^7.22.13",
+        "@babel/parser": "^7.22.15",
+        "@babel/types": "^7.22.15"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.22.4",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/traverse/-/traverse-7.22.4.tgz",
-      "integrity": "sha512-Tn1pDsjIcI+JcLKq1AVlZEr4226gpuAQTsLMorsYg9tuS/kG7nuwwJ4AB8jfQuEgb/COBwR/DqJxmoiYFu5/rQ==",
+      "version": "7.23.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/traverse/-/traverse-7.23.0.tgz",
+      "integrity": "sha512-t/QaEvyIoIkwzpiZ7aoSKK8kObQYeF7T2v+dazAYCb8SXtp58zEVkWW7zAnju8FNKNdr4ScAOEDmMItbyOmEYw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.21.4",
-        "@babel/generator": "^7.22.3",
-        "@babel/helper-environment-visitor": "^7.22.1",
-        "@babel/helper-function-name": "^7.21.0",
-        "@babel/helper-hoist-variables": "^7.18.6",
-        "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.22.4",
-        "@babel/types": "^7.22.4",
+        "@babel/code-frame": "^7.22.13",
+        "@babel/generator": "^7.23.0",
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-function-name": "^7.23.0",
+        "@babel/helper-hoist-variables": "^7.22.5",
+        "@babel/helper-split-export-declaration": "^7.22.6",
+        "@babel/parser": "^7.23.0",
+        "@babel/types": "^7.23.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -397,13 +403,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.22.4",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/types/-/types-7.22.4.tgz",
-      "integrity": "sha512-Tx9x3UBHTTsMSW85WB2kphxYQVvrZ/t1FxD88IpSgIjiUJlCm9z+xWIDwyo1vffTwSqteqyznB8ZE9vYYk16zA==",
+      "version": "7.23.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@babel/types/-/types-7.23.0.tgz",
+      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.21.5",
-        "@babel/helper-validator-identifier": "^7.19.1",
+        "@babel/helper-string-parser": "^7.22.5",
+        "@babel/helper-validator-identifier": "^7.22.20",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -411,9 +417,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.17.19",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
-      "integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
+      "version": "0.18.20",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
       "cpu": [
         "arm"
       ],
@@ -427,9 +433,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.17.19",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
-      "integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
+      "version": "0.18.20",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
       "cpu": [
         "arm64"
       ],
@@ -443,9 +449,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.17.19",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
-      "integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
+      "version": "0.18.20",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
       "cpu": [
         "x64"
       ],
@@ -459,9 +465,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.17.19",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
-      "integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
+      "version": "0.18.20",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
+      "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
       "cpu": [
         "arm64"
       ],
@@ -475,9 +481,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.17.19",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
-      "integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
+      "version": "0.18.20",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
       "cpu": [
         "x64"
       ],
@@ -491,9 +497,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.17.19",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
-      "integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
+      "version": "0.18.20",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
       "cpu": [
         "arm64"
       ],
@@ -507,9 +513,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.17.19",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
-      "integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
+      "version": "0.18.20",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
       "cpu": [
         "x64"
       ],
@@ -523,9 +529,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.17.19",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
-      "integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
+      "version": "0.18.20",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
       "cpu": [
         "arm"
       ],
@@ -539,9 +545,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.17.19",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
-      "integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
+      "version": "0.18.20",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
       "cpu": [
         "arm64"
       ],
@@ -555,9 +561,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.17.19",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
-      "integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
+      "version": "0.18.20",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
       "cpu": [
         "ia32"
       ],
@@ -571,9 +577,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.17.19",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
-      "integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
+      "version": "0.18.20",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
       "cpu": [
         "loong64"
       ],
@@ -587,9 +593,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.17.19",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
-      "integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
+      "version": "0.18.20",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
       "cpu": [
         "mips64el"
       ],
@@ -603,9 +609,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.17.19",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
-      "integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
+      "version": "0.18.20",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
       "cpu": [
         "ppc64"
       ],
@@ -619,9 +625,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.17.19",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
-      "integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
+      "version": "0.18.20",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
       "cpu": [
         "riscv64"
       ],
@@ -635,9 +641,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.17.19",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
-      "integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
+      "version": "0.18.20",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
       "cpu": [
         "s390x"
       ],
@@ -651,9 +657,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.17.19",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
-      "integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
+      "version": "0.18.20",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
       "cpu": [
         "x64"
       ],
@@ -667,9 +673,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.17.19",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
-      "integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
+      "version": "0.18.20",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
       "cpu": [
         "x64"
       ],
@@ -683,9 +689,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.17.19",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
-      "integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
+      "version": "0.18.20",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
       "cpu": [
         "x64"
       ],
@@ -699,9 +705,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.17.19",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
-      "integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
+      "version": "0.18.20",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
       "cpu": [
         "x64"
       ],
@@ -715,9 +721,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.17.19",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
-      "integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
+      "version": "0.18.20",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
       "cpu": [
         "arm64"
       ],
@@ -731,9 +737,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.17.19",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
-      "integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
+      "version": "0.18.20",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
       "cpu": [
         "ia32"
       ],
@@ -747,9 +753,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.17.19",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
-      "integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
+      "version": "0.18.20",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
       "cpu": [
         "x64"
       ],
@@ -779,9 +785,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.5.1",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@eslint-community/regexpp/-/regexpp-4.5.1.tgz",
-      "integrity": "sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==",
+      "version": "4.9.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@eslint-community/regexpp/-/regexpp-4.9.0.tgz",
+      "integrity": "sha512-zJmuCWj2VLBt4c25CfBIbMZLGLyhkvs7LznyVX5HfpzeocThgIj5XQK4L+g3U36mMcx8bPMhGyPpwCATamC4jQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -789,15 +795,15 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "2.0.3",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@eslint/eslintrc/-/eslintrc-2.0.3.tgz",
-      "integrity": "sha512-+5gy6OQfk+xx3q0d6jGZZC3f3KzAkXc/IanVxd1is/VIIziRqqt3ongQz0FiTUXqTk0c7aDB3OaFuKnuSoJicQ==",
+      "version": "2.1.2",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@eslint/eslintrc/-/eslintrc-2.1.2.tgz",
+      "integrity": "sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.5.2",
+        "espree": "^9.6.0",
         "globals": "^13.19.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
@@ -813,9 +819,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "13.20.0",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/globals/-/globals-13.20.0.tgz",
-      "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+      "version": "13.22.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/globals/-/globals-13.22.0.tgz",
+      "integrity": "sha512-H1Ddc/PbZHTDVJSnj8kWptIRSD6AM3pK+mKytuIVF4uoBV7rshFlhhvA58ceJ5wp3Er58w6zj7bykMpYXt3ETw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -829,9 +835,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.41.0",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@eslint/js/-/js-8.41.0.tgz",
-      "integrity": "sha512-LxcyMGxwmTh2lY9FwHPGWOHmYFCZvbrFCBZL4FzSSsxsRPuhrYUg/49/0KDfW8tnIEaEHtfmn6+NPN+1DqaNmA==",
+      "version": "8.50.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@eslint/js/-/js-8.50.0.tgz",
+      "integrity": "sha512-NCC3zz2+nvYd+Ckfh87rA47zfu2QsQpvc6k1yzTk+b9KzRj0wkGa8LSoGOXN6Zv4lRf/EIoZ80biDh9HOI+RNQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -839,9 +845,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.8",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
-      "integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
+      "version": "0.11.11",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@humanwhocodes/config-array/-/config-array-0.11.11.tgz",
+      "integrity": "sha512-N2brEuAadi0CcdeMXUkhbZB84eskAc8MEX1By6qEchoVywSgXPIjou4rYsl0V3Hj0ZnuGycGCjdNgockbzeWNA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -889,9 +895,9 @@
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.0",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "version": "3.1.1",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -913,20 +919,14 @@
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.18",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
-      "integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
+      "version": "0.3.19",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@jridgewell/trace-mapping/-/trace-mapping-0.3.19.tgz",
+      "integrity": "sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==",
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/resolve-uri": "3.1.0",
-        "@jridgewell/sourcemap-codec": "1.4.14"
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
-    },
-    "node_modules/@jridgewell/trace-mapping/node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.14",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -967,18 +967,18 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.6.2",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@remix-run/router/-/router-1.6.2.tgz",
-      "integrity": "sha512-LzqpSrMK/3JBAVBI9u3NWtOhWNw5AMQfrUFYB0+bDHTSw17z++WJLsPsxAuK+oSddsxk4d7F/JcdDPM1M5YAhA==",
+      "version": "1.9.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@remix-run/router/-/router-1.9.0.tgz",
+      "integrity": "sha512-bV63itrKBC0zdT27qYm6SDZHlkXwFL1xMBuhkn+X7l0+IIhNaH5wuuvZKp6eKhCD4KFhujhfhCT1YxXW6esUIA==",
       "license": "MIT",
       "engines": {
-        "node": ">=14"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/pluginutils": {
-      "version": "5.0.2",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
-      "integrity": "sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==",
+      "version": "5.0.4",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@rollup/pluginutils/-/pluginutils-5.0.4.tgz",
+      "integrity": "sha512-0KJnIoRI8A+a1dqOYLxH8vBf8bphDmty5QvIm2hqm7oFCFYKCAZWWd2hXgMibaPsNDhI0AtpYfQZJG47pt/k4g==",
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0",
@@ -998,17 +998,17 @@
       }
     },
     "node_modules/@sb1/ffe-account-selector-react": {
-      "version": "21.3.6",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-account-selector-react/-/ffe-account-selector-react-21.3.6.tgz",
-      "integrity": "sha512-yQLz2aZYEp75uJLEZGPstCBvyh91P3yzkKa4jQ8LEQGDobOhsZ2pI4iJuEBoVCpyqwrJnDrsyEjlTJCwrx1HZg==",
+      "version": "22.1.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-account-selector-react/-/ffe-account-selector-react-22.1.0.tgz",
+      "integrity": "sha512-lpTtyPP54OIkmC2c+7HWMLxVvpz4mhNrfklUFWzqmP6ORHszyCLut0QiG8MveD/W6/exSpjPBxUFj8Lw3fNwag==",
       "license": "MIT",
       "dependencies": {
-        "@sb1/ffe-form": "^23.0.7",
-        "@sb1/ffe-form-react": "^11.0.10",
-        "@sb1/ffe-formatters": "^4.0.12",
+        "@sb1/ffe-form": "^24.1.0",
+        "@sb1/ffe-form-react": "^13.0.3",
+        "@sb1/ffe-formatters": "^4.1.0",
         "@sb1/ffe-icons-react": "^7.3.5",
-        "@sb1/ffe-searchable-dropdown-react": "^15.1.6",
-        "@sb1/ffe-spinner-react": "^6.0.5",
+        "@sb1/ffe-searchable-dropdown-react": "^16.1.0",
+        "@sb1/ffe-spinner-react": "^6.0.6",
         "classnames": "^2.3.1",
         "prop-types": "^15.7.2",
         "react-auto-bind": "^0.4.2",
@@ -1020,21 +1020,21 @@
       }
     },
     "node_modules/@sb1/ffe-buttons": {
-      "version": "17.0.3",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-buttons/-/ffe-buttons-17.0.3.tgz",
-      "integrity": "sha512-J0q2m9jgZ2KJ6q9TTZUL258D5CEFzzDCHvXR3AZunFnFHg9ogUxTTVVzRBraOft4/hd3EJ9eTBG+tgIB2+xjCQ==",
+      "version": "17.1.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-buttons/-/ffe-buttons-17.1.0.tgz",
+      "integrity": "sha512-50RF+hn3FLkJr2ugKmWq7ZqJ9HCaUOcBtwd0UQ9DuGi2YuO5Qvd8BEFE9A//2agLnA+NAbXq26kiMIwuBl0vTg==",
       "license": "MIT",
       "dependencies": {
-        "@sb1/ffe-core": "^27.0.1"
+        "@sb1/ffe-core": "^27.1.0"
       }
     },
     "node_modules/@sb1/ffe-buttons-react": {
-      "version": "18.0.2",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-buttons-react/-/ffe-buttons-react-18.0.2.tgz",
-      "integrity": "sha512-CCRsCyyUES3TvaHPL8HEyDfACPoeu6fW3cLvhecTgGU+nmIB6QEH8v8VWjRGvraD8ypGLDVzl/4kheA0cam8Qw==",
+      "version": "18.0.5",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-buttons-react/-/ffe-buttons-react-18.0.5.tgz",
+      "integrity": "sha512-shocUQ/D9RVEBh7TMwifR3VjVIVDeGNiN3IMMNpa32zrCw/zYdyorQfZg1/e9JvPvZAm768aE65vGi2yffrMug==",
       "license": "MIT",
       "dependencies": {
-        "@sb1/ffe-buttons": "^17.0.3",
+        "@sb1/ffe-buttons": "^17.1.0",
         "@sb1/ffe-icons-react": "^7.3.5",
         "classnames": "^2.3.1",
         "prop-types": "^15.7.2"
@@ -1044,21 +1044,21 @@
       }
     },
     "node_modules/@sb1/ffe-cards": {
-      "version": "15.0.3",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-cards/-/ffe-cards-15.0.3.tgz",
-      "integrity": "sha512-w8rOg4pprv+VSu8hOx8yFqkowb3MVA9Qs2M0nRHn6Ioh62eoFb4Bhugx14QIBS4B0B1it2JyXCYSeSKN95tAiQ==",
+      "version": "16.2.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-cards/-/ffe-cards-16.2.0.tgz",
+      "integrity": "sha512-XHsIyd1la1LF7Nh4fG/FegPK1zbH/lzmRp90beBDZ9BMMH1DgEf+/F3eDLseCRg/XUg1KOT7LNpmse5cZ/B7rw==",
       "license": "MIT",
       "dependencies": {
-        "@sb1/ffe-core": "^27.0.1"
+        "@sb1/ffe-core": "^27.1.0"
       }
     },
     "node_modules/@sb1/ffe-cards-react": {
-      "version": "11.0.2",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-cards-react/-/ffe-cards-react-11.0.2.tgz",
-      "integrity": "sha512-VvWdJ+DEFcPVbBpgrkwki5GoO2P0qrkj0aom0u7ZE7VDp23aIQ8jl1KUUW0bBunQ3ZQjCOwJwa5XN30MBUM0yg==",
+      "version": "12.1.2",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-cards-react/-/ffe-cards-react-12.1.2.tgz",
+      "integrity": "sha512-jlyig6GoqiUcUo6fBMyKnPNq1a3reMKRFjQhwRvemSxtPOlJzRYlG5CK01vbPQdY2CECWLFRlqU9IWFak81JDg==",
       "license": "MIT",
       "dependencies": {
-        "@sb1/ffe-cards": "^15.0.3",
+        "@sb1/ffe-cards": "^16.2.0",
         "prop-types": "^15.7.2"
       },
       "peerDependencies": {
@@ -1066,9 +1066,9 @@
       }
     },
     "node_modules/@sb1/ffe-chart-donut-react": {
-      "version": "5.2.0",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-chart-donut-react/-/ffe-chart-donut-react-5.2.0.tgz",
-      "integrity": "sha512-bKmhSIQ/eXiA/RlsWK+lvDXa2RT35Kr1WhgsHWEJfbaWm72EDdl8cmmav7W/aTvKb6l2gRPT9qAp5OM10/lJ3Q==",
+      "version": "5.3.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-chart-donut-react/-/ffe-chart-donut-react-5.3.0.tgz",
+      "integrity": "sha512-lbEQBBRRtX7uqRhQFymN4CadXX/Ly6HFcWqtykcz/8ibOOgdnjjjjjq6LHXaFZTvh4CQu9V9+wQdN/PEPu7LDA==",
       "license": "MIT",
       "dependencies": {
         "prop-types": "^15.7.2"
@@ -1078,12 +1078,12 @@
       }
     },
     "node_modules/@sb1/ffe-collapse-react": {
-      "version": "2.0.3",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-collapse-react/-/ffe-collapse-react-2.0.3.tgz",
-      "integrity": "sha512-pgRT4GgWcBH4FTDQsAJL4CET0EEzJV+9qKDLOZdsfubyR3ytrdvCGqEpu4ZCoii9RqPOp8Gf3q8jRGKn9+pB2A==",
+      "version": "2.0.4",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-collapse-react/-/ffe-collapse-react-2.0.4.tgz",
+      "integrity": "sha512-PQda+dNYEwggpCXT4CWOqE9r37NXCybRml/wz2hw4M5LXldgdGPKu6EaMZ5lqsd/CWYszu4tAiEkhWfpZ06sIA==",
       "license": "MIT",
       "dependencies": {
-        "@sb1/ffe-core": "^27.0.1",
+        "@sb1/ffe-core": "^27.1.0",
         "classnames": "^2.3.1"
       },
       "peerDependencies": {
@@ -1091,18 +1091,18 @@
       }
     },
     "node_modules/@sb1/ffe-core": {
-      "version": "27.0.1",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-core/-/ffe-core-27.0.1.tgz",
-      "integrity": "sha512-ts6c/off57GSJ4Wjcm5lWVAGleju8jCoQK0+5MYZMAiVWuv4sOPRoh0imO9U83aGsG8TVBgn4FL8WDnnrnp5BQ==",
+      "version": "27.1.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-core/-/ffe-core-27.1.0.tgz",
+      "integrity": "sha512-W9qZEqY1BUHyfClxeenrs0grHAxChtsRnKt80orWy54pAfrcI4HXxv4Qumln44GY8vblsthb/Fv/RwbuE0zd/Q==",
       "license": "MIT"
     },
     "node_modules/@sb1/ffe-core-react": {
-      "version": "7.1.1",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-core-react/-/ffe-core-react-7.1.1.tgz",
-      "integrity": "sha512-oD2g/74vpUaEAI2Bi4Y/MTzw7IrPyZR+BPUy6nxf8QiCq2kncTSM8L+D4M9RLV25gxOroMKoYGhd6G9767Tm8A==",
+      "version": "7.1.2",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-core-react/-/ffe-core-react-7.1.2.tgz",
+      "integrity": "sha512-QRIIBgzAyRQPSpdE24Rg4+KDFtXfG2aLLkdkYtbqmh7tsPpDe2BVHF//PEXUFiyKXl9bvOvTAF2xsVT4EOPP0Q==",
       "license": "MIT",
       "dependencies": {
-        "@sb1/ffe-core": "^27.0.1",
+        "@sb1/ffe-core": "^27.1.0",
         "classnames": "^2.3.1",
         "prop-types": "^15.7.2"
       },
@@ -1111,23 +1111,23 @@
       }
     },
     "node_modules/@sb1/ffe-datepicker": {
-      "version": "11.0.9",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-datepicker/-/ffe-datepicker-11.0.9.tgz",
-      "integrity": "sha512-UhkeTi7gILn3wBCyth+d66GoB9GwfUWtTgZp6ysEz7Vi9mdD+EJaGt+tNllJOOx+tU6fArspuPk0PGvNd1pqvQ==",
+      "version": "11.1.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-datepicker/-/ffe-datepicker-11.1.0.tgz",
+      "integrity": "sha512-6+wTqOnfzQH7M5hzFLjC3V+RvTPWTqSBex+ail3196ztuUc7Gz1DUc4IVPB97ZirN8q3Jg0oJQ91zZnqlGDtPQ==",
       "license": "MIT",
       "dependencies": {
-        "@sb1/ffe-core": "^27.0.1",
-        "@sb1/ffe-form": "^24.0.1"
+        "@sb1/ffe-core": "^27.1.0",
+        "@sb1/ffe-form": "^24.1.0"
       }
     },
     "node_modules/@sb1/ffe-datepicker-react": {
-      "version": "6.0.11",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-datepicker-react/-/ffe-datepicker-react-6.0.11.tgz",
-      "integrity": "sha512-O+DG8pJar9xkHVm+72hNnOAcvXqEyqEAbxKvCoy3wR2uAhGfLg0mWj1SkYK31KFl0Ty2FIrQkfLwM/01MxmbNA==",
+      "version": "6.0.13",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-datepicker-react/-/ffe-datepicker-react-6.0.13.tgz",
+      "integrity": "sha512-zI6MtrXnzwEDpzOf4+2K2Fv2eZUL4KqCCE+AoS6/R+8n7EtrYPXxGRKDmDN8CFOnTAi005dUWE9YoBLuYV4xtw==",
       "license": "MIT",
       "dependencies": {
-        "@sb1/ffe-datepicker": "^11.0.9",
-        "@sb1/ffe-form": "^24.0.1",
+        "@sb1/ffe-datepicker": "^11.1.0",
+        "@sb1/ffe-form": "^24.1.0",
         "@sb1/ffe-icons-react": "^7.3.5",
         "classnames": "^2.3.1",
         "lodash.debounce": "^4.0.8",
@@ -1140,44 +1140,25 @@
         "react": ">=16.9.0"
       }
     },
-    "node_modules/@sb1/ffe-datepicker-react/node_modules/@sb1/ffe-form": {
-      "version": "24.0.1",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-form/-/ffe-form-24.0.1.tgz",
-      "integrity": "sha512-9lo51Dnfj1iOxjFTzWmIPhHRW1aFRqYBfXyBgX2Tf9I3NkmDt1L71U7UVROOxjSz481nQjZVzqAfzicj934eCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@sb1/ffe-buttons": "^17.0.3",
-        "@sb1/ffe-core": "^27.0.1"
-      }
-    },
-    "node_modules/@sb1/ffe-datepicker/node_modules/@sb1/ffe-form": {
-      "version": "24.0.1",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-form/-/ffe-form-24.0.1.tgz",
-      "integrity": "sha512-9lo51Dnfj1iOxjFTzWmIPhHRW1aFRqYBfXyBgX2Tf9I3NkmDt1L71U7UVROOxjSz481nQjZVzqAfzicj934eCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@sb1/ffe-buttons": "^17.0.3",
-        "@sb1/ffe-core": "^27.0.1"
-      }
-    },
     "node_modules/@sb1/ffe-form": {
-      "version": "23.0.7",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-form/-/ffe-form-23.0.7.tgz",
-      "integrity": "sha512-79ZZZwOSGR3ogYIXqq3Uso5dNYEq2taaT2hmG9FduoPa5/O7Pg6jFBVM7Z+BLN81RNstT1Pu1b1EzXYuIC0yvg==",
+      "version": "24.1.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-form/-/ffe-form-24.1.0.tgz",
+      "integrity": "sha512-glQpBW58BtyvWm3mpgsv1PipRVDAyGSnh735uRnEscXCvt4Ry3ZcqQNusClGHTrA8aXwMewse4H0iKUSB2QGwA==",
       "license": "MIT",
       "dependencies": {
-        "@sb1/ffe-buttons": "^17.0.3",
-        "@sb1/ffe-core": "^27.0.1"
+        "@sb1/ffe-buttons": "^17.1.0",
+        "@sb1/ffe-core": "^27.1.0"
       }
     },
     "node_modules/@sb1/ffe-form-react": {
-      "version": "11.0.10",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-form-react/-/ffe-form-react-11.0.10.tgz",
-      "integrity": "sha512-V5tFPC7Ur4mHC5pzlb4LTi1uey/hy3Jm9oToWi0xrhy8OBW0qB+p0QYxgdXMbIS1LVGvYCy5LZ1TUPWNH2xX/w==",
+      "version": "13.0.3",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-form-react/-/ffe-form-react-13.0.3.tgz",
+      "integrity": "sha512-o5OlKUutdnBuABkbiLdD1ukHV1wDpK6jbqJtSqNR06DKqbicdXKu3rd+S8cNPL+gCuQJmKxCHDklXO6VeVl/xw==",
       "license": "MIT",
       "dependencies": {
-        "@sb1/ffe-collapse-react": "^2.0.3",
-        "@sb1/ffe-form": "^23.0.7",
+        "@sb1/ffe-collapse-react": "^2.0.4",
+        "@sb1/ffe-form": "^24.1.0",
+        "@sb1/ffe-icons-react": "^7.3.5",
         "classnames": "^2.3.1",
         "uuid": "^9.0.0"
       },
@@ -1186,30 +1167,30 @@
       }
     },
     "node_modules/@sb1/ffe-formatters": {
-      "version": "4.0.12",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-formatters/-/ffe-formatters-4.0.12.tgz",
-      "integrity": "sha512-Baq2ML92PuGYGQ9D1mwQKvj1/gfXdRyQyvFxbcT2CzNoba7//cRvwrKgbdtlw95eHFmlbVo3S7Cmpj85c1g5Hw==",
+      "version": "4.1.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-formatters/-/ffe-formatters-4.1.0.tgz",
+      "integrity": "sha512-AlLowQHdF8MxtoNCE0FsZyuvGPFsErGfJF8scXkwqzt+ujzDeqkYCvdJGmxllgNz31Rr4/iR2z5NO8o19Kt+Eg==",
       "license": "MIT",
       "dependencies": {
         "underscore.string": "^3.3.4"
       }
     },
     "node_modules/@sb1/ffe-grid": {
-      "version": "14.0.4",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-grid/-/ffe-grid-14.0.4.tgz",
-      "integrity": "sha512-9CohwktmgLpQwtHyMLZwlmA17jcnGOCenhtMSX9cmTV5QyZUllvRHacCWkw3nMhBTxsYmUpx5QCmyqw8TrcEkw==",
+      "version": "14.0.5",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-grid/-/ffe-grid-14.0.5.tgz",
+      "integrity": "sha512-xJfjqB0UyxA3YHHuFVSQscaAkqCDxS7nHW9jnCS/GKq2GGBY/b41eOvFBHBcV5eJ+L7xixAB9p9H+jFvshzxrg==",
       "license": "MIT",
       "dependencies": {
-        "@sb1/ffe-core": "^27.0.1"
+        "@sb1/ffe-core": "^27.1.0"
       }
     },
     "node_modules/@sb1/ffe-grid-react": {
-      "version": "13.0.5",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-grid-react/-/ffe-grid-react-13.0.5.tgz",
-      "integrity": "sha512-8A/Lm49BbiFEN6SQQpWoLGs2PSepXhDfpJTno/RHU0hOI5z0zDUnTRW/ZGPg2Zj81p+ZfehRsuYBUxX/yZ0pxQ==",
+      "version": "13.0.6",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-grid-react/-/ffe-grid-react-13.0.6.tgz",
+      "integrity": "sha512-02OHTaue0ROK2VqYv2sQDJc51gtHfMH9pfAl9FqHU+6HqgkGR/gcVtXyBd/ag7lTiyqdLGHHCtm8waptVUIvNA==",
       "license": "MIT",
       "dependencies": {
-        "@sb1/ffe-grid": "^14.0.4",
+        "@sb1/ffe-grid": "^14.0.5",
         "classnames": "^2.3.1"
       },
       "peerDependencies": {
@@ -1217,9 +1198,9 @@
       }
     },
     "node_modules/@sb1/ffe-header": {
-      "version": "19.0.2",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-header/-/ffe-header-19.0.2.tgz",
-      "integrity": "sha512-9onoZFBqxHul6kCQWKgApNSj/YsggR24vIcZcjzKJCLzbMz/Z5f3VfhNJmmoPgmlXCmr2tkcbZzn+zojvIA7Og==",
+      "version": "19.1.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-header/-/ffe-header-19.1.0.tgz",
+      "integrity": "sha512-xlIK49FVevk/QLKJR/GDRtZYmYIbHKmWmD5O5rmQKC/ZIPBOsiiHTJ67Ci6gAmifVy2qG4c6EXj49NJjGoAVlA==",
       "license": "MIT"
     },
     "node_modules/@sb1/ffe-icons-react": {
@@ -1235,22 +1216,22 @@
       }
     },
     "node_modules/@sb1/ffe-message-box": {
-      "version": "11.0.4",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-message-box/-/ffe-message-box-11.0.4.tgz",
-      "integrity": "sha512-LH0Vu7uSU7CpbZDHsJCx459k12ODxQZSlGCmTBNQUiGZt8Z/zXR47bXbmNlnAvxU7LbnRwYKObS7HGNJLBKBeQ==",
+      "version": "11.1.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-message-box/-/ffe-message-box-11.1.0.tgz",
+      "integrity": "sha512-fx3pdhPjU7j12IfNCIKl4ZcuI1QSTTQDZe9wlKMk7JlkS7Na1znbAoEfC0s4mIOD9fnB4g3/RsVlplcUKnO0mw==",
       "license": "MIT",
       "dependencies": {
-        "@sb1/ffe-core": "^27.0.1"
+        "@sb1/ffe-core": "^27.1.0"
       }
     },
     "node_modules/@sb1/ffe-message-box-react": {
-      "version": "8.0.7",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-message-box-react/-/ffe-message-box-react-8.0.7.tgz",
-      "integrity": "sha512-51K3pWM5ZnHnwrCbV4LvzXabGPUEjaX/9Qw/Di9f0vLnskpf78KkC13Ra7/989RxfGH1VWva0m7s5DRTrmqIjQ==",
+      "version": "9.0.3",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-message-box-react/-/ffe-message-box-react-9.0.3.tgz",
+      "integrity": "sha512-DBmw0dWDYdklA6PhRsEmJdFUgokKpUpp2QlDsiDUN5JZ6RiIoeMNBxVQZw0FDVyMr72KfJgJF3j3CKrbNfiEbg==",
       "license": "MIT",
       "dependencies": {
         "@sb1/ffe-icons-react": "^7.3.5",
-        "@sb1/ffe-message-box": "^11.0.4",
+        "@sb1/ffe-message-box": "^11.1.0",
         "classnames": "^2.3.1"
       },
       "peerDependencies": {
@@ -1258,53 +1239,42 @@
       }
     },
     "node_modules/@sb1/ffe-searchable-dropdown-react": {
-      "version": "15.2.3",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-searchable-dropdown-react/-/ffe-searchable-dropdown-react-15.2.3.tgz",
-      "integrity": "sha512-GzJKsO3Hc3vgBdSJeEq2h8ynS4HqYYezd0xCq1tKWwf3Xb/3cWBd5VJX+XcPra7IN8koTMUXoybw3aLTUgwwJA==",
+      "version": "16.1.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-searchable-dropdown-react/-/ffe-searchable-dropdown-react-16.1.0.tgz",
+      "integrity": "sha512-Z15hRls3CqDX9o3Ji+eS2L7mcWP/fsON5wgD+sNfqmxQBMUeclb6XJw4pKPEzrf5UZEaTijrmCtE151qEFGR/w==",
       "license": "MIT",
       "dependencies": {
-        "@sb1/ffe-core-react": "^7.1.1",
-        "@sb1/ffe-form": "^24.0.1",
+        "@sb1/ffe-core-react": "^7.1.2",
+        "@sb1/ffe-form": "^24.1.0",
         "@sb1/ffe-icons-react": "^7.3.5",
-        "@sb1/ffe-spinner-react": "^6.0.5",
+        "@sb1/ffe-spinner-react": "^6.0.6",
         "classnames": "^2.3.1",
         "compute-scroll-into-view": "^1.0.17",
         "lodash.isequal": "^4.5.0",
         "prop-types": "^15.7.2",
         "react-custom-scrollbars-2": "^4.3.0",
-        "react-virtualized": "^9.22.3",
         "uuid": "^9.0.0"
       },
       "peerDependencies": {
         "react": ">=16.9.0"
       }
     },
-    "node_modules/@sb1/ffe-searchable-dropdown-react/node_modules/@sb1/ffe-form": {
-      "version": "24.0.1",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-form/-/ffe-form-24.0.1.tgz",
-      "integrity": "sha512-9lo51Dnfj1iOxjFTzWmIPhHRW1aFRqYBfXyBgX2Tf9I3NkmDt1L71U7UVROOxjSz481nQjZVzqAfzicj934eCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@sb1/ffe-buttons": "^17.0.3",
-        "@sb1/ffe-core": "^27.0.1"
-      }
-    },
     "node_modules/@sb1/ffe-spinner": {
-      "version": "5.0.4",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-spinner/-/ffe-spinner-5.0.4.tgz",
-      "integrity": "sha512-2KfIm/yB47Aek8p03/ReYGM9Z438r6nrrkHw2XSu4VCJnDt9URu7Gik46eGYR48CWB8iFM3B7oGy9fIohcbxEg==",
+      "version": "5.0.5",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-spinner/-/ffe-spinner-5.0.5.tgz",
+      "integrity": "sha512-o6yi57tEnuRJFFcn5gT2ddxciU2pRV2S44iRiBaLunDUs/06Ys1I6Z9XHdyfOC+0iWV3ug69daf/PAUl1Dk/Kw==",
       "license": "MIT",
       "dependencies": {
-        "@sb1/ffe-core": "^27.0.1"
+        "@sb1/ffe-core": "^27.1.0"
       }
     },
     "node_modules/@sb1/ffe-spinner-react": {
-      "version": "6.0.5",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-spinner-react/-/ffe-spinner-react-6.0.5.tgz",
-      "integrity": "sha512-Dx/THt53HMplAdldT2QhKyTads4qYGVW08Gju2rZ+2fINyBXfECbLG0zeqQj4qNlbPNZgjN/p/dzhdc0PhQpJw==",
+      "version": "6.0.6",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-spinner-react/-/ffe-spinner-react-6.0.6.tgz",
+      "integrity": "sha512-8xK9p0Zan/QtmEoLTlRzbixmrcc7Rjmwhofg49MmxGpKNGnJ2MB7ccgdcBEVznG73RwEzRXpK5Obbrw6BuhAMw==",
       "license": "MIT",
       "dependencies": {
-        "@sb1/ffe-spinner": "^5.0.4",
+        "@sb1/ffe-spinner": "^5.0.5",
         "prop-types": "^15.7.2"
       },
       "peerDependencies": {
@@ -1312,21 +1282,21 @@
       }
     },
     "node_modules/@sb1/ffe-tabs": {
-      "version": "13.0.3",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-tabs/-/ffe-tabs-13.0.3.tgz",
-      "integrity": "sha512-zmLDNSmzd/UiSuXtqBBufykZOUtRUZxfY+OTagt62ZHxbF5Aw+0wHGg35ENxP7XmhXJfQxmKuk9Pi+blcNwrow==",
+      "version": "13.1.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-tabs/-/ffe-tabs-13.1.0.tgz",
+      "integrity": "sha512-DSIMb/+p6JEC38TR01aXRIjfR9Enc4HmvIP9N99PJLqGs5xzL+ZRJz+NHIfvgnF/hpIMk//MpwFpCNCgaA+Fcw==",
       "license": "MIT",
       "dependencies": {
-        "@sb1/ffe-core": "^27.0.1"
+        "@sb1/ffe-core": "^27.1.0"
       }
     },
     "node_modules/@sb1/ffe-tabs-react": {
-      "version": "8.0.3",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-tabs-react/-/ffe-tabs-react-8.0.3.tgz",
-      "integrity": "sha512-Z1ZHnVcl7rW95Z0WDiTVsiGtGTpRo4WI0U6N07NpFZyK3ZBgfjygof50UBPB1stSORsO4T6QfLdNA/hzF+TEIw==",
+      "version": "8.0.4",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@sb1/ffe-tabs-react/-/ffe-tabs-react-8.0.4.tgz",
+      "integrity": "sha512-RJH9Y9rtgR2uuuHbxnrOYynVrJtCrgFpfegPk1FOLFtgEa5TCJBputiwyylPzcT+fpsGkiw6FiX1DJccIKfdGg==",
       "license": "MIT",
       "dependencies": {
-        "@sb1/ffe-tabs": "^13.0.3",
+        "@sb1/ffe-tabs": "^13.1.0",
         "classnames": "^2.3.1",
         "prop-types": "^15.7.2"
       },
@@ -1341,9 +1311,9 @@
       "license": "SEE LICENSE IN README.md"
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
-      "version": "7.0.0",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-7.0.0.tgz",
-      "integrity": "sha512-khWbXesWIP9v8HuKCl2NU2HNAyqpSQ/vkIl36Nbn4HIwEYSRWL0H7Gs6idJdha2DkpFDWlsqMELvoCE8lfFY6Q==",
+      "version": "8.0.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-8.0.0.tgz",
+      "integrity": "sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g==",
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -1357,9 +1327,9 @@
       }
     },
     "node_modules/@svgr/babel-plugin-remove-jsx-attribute": {
-      "version": "7.0.0",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-7.0.0.tgz",
-      "integrity": "sha512-iiZaIvb3H/c7d3TH2HBeK91uI2rMhZNwnsIrvd7ZwGLkFw6mmunOCoVnjdYua662MqGFxlN9xTq4fv9hgR4VXQ==",
+      "version": "8.0.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-8.0.0.tgz",
+      "integrity": "sha512-BcCkm/STipKvbCl6b7QFrMh/vx00vIP63k2eM66MfHJzPr6O2U0jYEViXkHJWqXqQYjdeA9cuCl5KWmlwjDvbA==",
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -1373,9 +1343,9 @@
       }
     },
     "node_modules/@svgr/babel-plugin-remove-jsx-empty-expression": {
-      "version": "7.0.0",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-7.0.0.tgz",
-      "integrity": "sha512-sQQmyo+qegBx8DfFc04PFmIO1FP1MHI1/QEpzcIcclo5OAISsOJPW76ZIs0bDyO/DBSJEa/tDa1W26pVtt0FRw==",
+      "version": "8.0.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-8.0.0.tgz",
+      "integrity": "sha512-5BcGCBfBxB5+XSDSWnhTThfI9jcO5f0Ai2V24gZpG+wXF14BzwxxdDb4g6trdOux0rhibGs385BeFMSmxtS3uA==",
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -1389,9 +1359,9 @@
       }
     },
     "node_modules/@svgr/babel-plugin-replace-jsx-attribute-value": {
-      "version": "7.0.0",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-7.0.0.tgz",
-      "integrity": "sha512-i6MaAqIZXDOJeikJuzocByBf8zO+meLwfQ/qMHIjCcvpnfvWf82PFvredEZElErB5glQFJa2KVKk8N2xV6tRRA==",
+      "version": "8.0.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-8.0.0.tgz",
+      "integrity": "sha512-KVQ+PtIjb1BuYT3ht8M5KbzWBhdAjjUPdlMtpuw/VjT8coTrItWX6Qafl9+ji831JaJcu6PJNKCV0bp01lBNzQ==",
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -1405,9 +1375,9 @@
       }
     },
     "node_modules/@svgr/babel-plugin-svg-dynamic-title": {
-      "version": "7.0.0",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-7.0.0.tgz",
-      "integrity": "sha512-BoVSh6ge3SLLpKC0pmmN9DFlqgFy4NxNgdZNLPNJWBUU7TQpDWeBuyVuDW88iXydb5Cv0ReC+ffa5h3VrKfk1w==",
+      "version": "8.0.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-8.0.0.tgz",
+      "integrity": "sha512-omNiKqwjNmOQJ2v6ge4SErBbkooV2aAWwaPFs2vUY7p7GhVkzRkJ00kILXQvRhA6miHnNpXv7MRnnSjdRjK8og==",
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -1421,9 +1391,9 @@
       }
     },
     "node_modules/@svgr/babel-plugin-svg-em-dimensions": {
-      "version": "7.0.0",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-7.0.0.tgz",
-      "integrity": "sha512-tNDcBa+hYn0gO+GkP/AuNKdVtMufVhU9fdzu+vUQsR18RIJ9RWe7h/pSBY338RO08wArntwbDk5WhQBmhf2PaA==",
+      "version": "8.0.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-8.0.0.tgz",
+      "integrity": "sha512-mURHYnu6Iw3UBTbhGwE/vsngtCIbHE43xCRK7kCw4t01xyGqb2Pd+WXekRRoFOBIY29ZoOhUCTEweDMdrjfi9g==",
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -1437,9 +1407,9 @@
       }
     },
     "node_modules/@svgr/babel-plugin-transform-react-native-svg": {
-      "version": "7.0.0",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-7.0.0.tgz",
-      "integrity": "sha512-qw54u8ljCJYL2KtBOjI5z7Nzg8LnSvQOP5hPKj77H4VQL4+HdKbAT5pnkkZLmHKYwzsIHSYKXxHouD8zZamCFQ==",
+      "version": "8.1.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-8.1.0.tgz",
+      "integrity": "sha512-Tx8T58CHo+7nwJ+EhUwx3LfdNSG9R2OKfaIXXs5soiy5HtgoAEkDay9LIimLOcG8dJQH1wPZp/cnAv6S9CrR1Q==",
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -1453,9 +1423,9 @@
       }
     },
     "node_modules/@svgr/babel-plugin-transform-svg-component": {
-      "version": "7.0.0",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-7.0.0.tgz",
-      "integrity": "sha512-CcFECkDj98daOg9jE3Bh3uyD9kzevCAnZ+UtzG6+BQG/jOQ2OA3jHnX6iG4G1MCJkUQFnUvEv33NvQfqrb/F3A==",
+      "version": "8.0.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-8.0.0.tgz",
+      "integrity": "sha512-DFx8xa3cZXTdb/k3kfPeaixecQLgKh5NVBMwD0AQxOzcZawK4oo1Jh9LbrcACUivsCA7TLG8eeWgrDXjTMhRmw==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -1469,19 +1439,19 @@
       }
     },
     "node_modules/@svgr/babel-preset": {
-      "version": "7.0.0",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@svgr/babel-preset/-/babel-preset-7.0.0.tgz",
-      "integrity": "sha512-EX/NHeFa30j5UjldQGVQikuuQNHUdGmbh9kEpBKofGUtF0GUPJ4T4rhoYiqDAOmBOxojyot36JIFiDUHUK1ilQ==",
+      "version": "8.1.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@svgr/babel-preset/-/babel-preset-8.1.0.tgz",
+      "integrity": "sha512-7EYDbHE7MxHpv4sxvnVPngw5fuR6pw79SkcrILHJ/iMpuKySNCl5W1qcwPEpU+LgyRXOaAFgH0KhwD18wwg6ug==",
       "license": "MIT",
       "dependencies": {
-        "@svgr/babel-plugin-add-jsx-attribute": "^7.0.0",
-        "@svgr/babel-plugin-remove-jsx-attribute": "^7.0.0",
-        "@svgr/babel-plugin-remove-jsx-empty-expression": "^7.0.0",
-        "@svgr/babel-plugin-replace-jsx-attribute-value": "^7.0.0",
-        "@svgr/babel-plugin-svg-dynamic-title": "^7.0.0",
-        "@svgr/babel-plugin-svg-em-dimensions": "^7.0.0",
-        "@svgr/babel-plugin-transform-react-native-svg": "^7.0.0",
-        "@svgr/babel-plugin-transform-svg-component": "^7.0.0"
+        "@svgr/babel-plugin-add-jsx-attribute": "8.0.0",
+        "@svgr/babel-plugin-remove-jsx-attribute": "8.0.0",
+        "@svgr/babel-plugin-remove-jsx-empty-expression": "8.0.0",
+        "@svgr/babel-plugin-replace-jsx-attribute-value": "8.0.0",
+        "@svgr/babel-plugin-svg-dynamic-title": "8.0.0",
+        "@svgr/babel-plugin-svg-em-dimensions": "8.0.0",
+        "@svgr/babel-plugin-transform-react-native-svg": "8.1.0",
+        "@svgr/babel-plugin-transform-svg-component": "8.0.0"
       },
       "engines": {
         "node": ">=14"
@@ -1495,15 +1465,16 @@
       }
     },
     "node_modules/@svgr/core": {
-      "version": "7.0.0",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@svgr/core/-/core-7.0.0.tgz",
-      "integrity": "sha512-ztAoxkaKhRVloa3XydohgQQCb0/8x9T63yXovpmHzKMkHO6pkjdsIAWKOS4bE95P/2quVh1NtjSKlMRNzSBffw==",
+      "version": "8.1.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@svgr/core/-/core-8.1.0.tgz",
+      "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.21.3",
-        "@svgr/babel-preset": "^7.0.0",
+        "@svgr/babel-preset": "8.1.0",
         "camelcase": "^6.2.0",
-        "cosmiconfig": "^8.1.3"
+        "cosmiconfig": "^8.1.3",
+        "snake-case": "^3.0.4"
       },
       "engines": {
         "node": ">=14"
@@ -1514,9 +1485,9 @@
       }
     },
     "node_modules/@svgr/hast-util-to-babel-ast": {
-      "version": "7.0.0",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-7.0.0.tgz",
-      "integrity": "sha512-42Ej9sDDEmsJKjrfQ1PHmiDiHagh/u9AHO9QWbeNx4KmD9yS5d1XHmXUNINfUcykAU+4431Cn+k6Vn5mWBYimQ==",
+      "version": "8.0.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-8.0.0.tgz",
+      "integrity": "sha512-EbDKwO9GpfWP4jN9sGdYwPBU0kdomaPIL2Eu4YwmgP+sJeXT+L7bMwJUBnhzfH8Q2qMBqZ4fJwpCyYsAN3mt2Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.21.3",
@@ -1531,14 +1502,14 @@
       }
     },
     "node_modules/@svgr/plugin-jsx": {
-      "version": "7.0.0",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@svgr/plugin-jsx/-/plugin-jsx-7.0.0.tgz",
-      "integrity": "sha512-SWlTpPQmBUtLKxXWgpv8syzqIU8XgFRvyhfkam2So8b3BE0OS0HPe5UfmlJ2KIC+a7dpuuYovPR2WAQuSyMoPw==",
+      "version": "8.1.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@svgr/plugin-jsx/-/plugin-jsx-8.1.0.tgz",
+      "integrity": "sha512-0xiIyBsLlr8quN+WyuxooNW9RJ0Dpr8uOnH/xrCVO8GLUcwHISwj1AG0k+LFzteTkAA0GbX0kj9q6Dk70PTiPA==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.21.3",
-        "@svgr/babel-preset": "^7.0.0",
-        "@svgr/hast-util-to-babel-ast": "^7.0.0",
+        "@svgr/babel-preset": "8.1.0",
+        "@svgr/hast-util-to-babel-ast": "8.0.0",
         "svg-parser": "^2.0.4"
       },
       "engines": {
@@ -1547,25 +1518,73 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/gregberge"
+      },
+      "peerDependencies": {
+        "@svgr/core": "*"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.2",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@types/babel__core/-/babel__core-7.20.2.tgz",
+      "integrity": "sha512-pNpr1T1xLUc2l3xJKuPtsEky3ybxN3m4fJkknfIpTCTfIZCDW57oAg+EfCgIIp2rvCe0Wn++/FfodDS4YXxBwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.6.5",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@types/babel__generator/-/babel__generator-7.6.5.tgz",
+      "integrity": "sha512-h9yIuWbJKdOPLJTbmSpPzkF67e659PbQDba7ifWm5BJ8xTv+sDmS7rFmywkWOvXedGTivCdeGSIIX8WLcRTz8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.2",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@types/babel__template/-/babel__template-7.4.2.tgz",
+      "integrity": "sha512-/AVzPICMhMOMYoSx9MoKpGDKdBRsIXMNByh1PXSZoa+v6ZoLa8xxtsT/uLQ/NJm0XVAWl/BvId4MlDeXJaeIZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.20.2",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@types/babel__traverse/-/babel__traverse-7.20.2.tgz",
+      "integrity": "sha512-ojlGK1Hsfce93J0+kn3H5R73elidKUaZonirN33GSmgTUMpzI/MIFfSpF3haANe3G1bEBS9/9/QEqwTzwqFsKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.20.7"
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.1",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@types/estree/-/estree-1.0.1.tgz",
-      "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==",
+      "version": "1.0.2",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@types/estree/-/estree-1.0.2.tgz",
+      "integrity": "sha512-VeiPZ9MMwXjO32/Xu7+OwflfmeoRwkE/qzndw42gGtgJwZopBnzy2gD//NN1+go1mADzkDcqf/KnFRSjTJ8xJA==",
       "license": "MIT"
     },
     "node_modules/@types/prop-types": {
-      "version": "15.7.5",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
+      "version": "15.7.7",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@types/prop-types/-/prop-types-15.7.7.tgz",
+      "integrity": "sha512-FbtmBWCcSa2J4zL781Zf1p5YUBXQomPEcep9QZCfRfQgTxz3pJWiDFLebohZ9fFntX5ibzOkSsrJ0TEew8cAog==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "18.2.7",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@types/react/-/react-18.2.7.tgz",
-      "integrity": "sha512-ojrXpSH2XFCmHm7Jy3q44nXDyN54+EYKP2lBhJ2bqfyPj6cIUW/FZW/Csdia34NQgq7KYcAlHi5184m4X88+yw==",
+      "version": "18.2.23",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@types/react/-/react-18.2.23.tgz",
+      "integrity": "sha512-qHLW6n1q2+7KyBEYnrZpcsAmU/iiCh9WGCKgXvMxx89+TYdJWRjZohVIo9XTcoLhfX3+/hP0Pbulu3bCZQ9PSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1575,9 +1594,9 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.2.4",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@types/react-dom/-/react-dom-18.2.4.tgz",
-      "integrity": "sha512-G2mHoTMTL4yoydITgOGwWdWMVd8sNgyEP85xVmMKAPUBwQWm9wBPQUmvbeF4V3WBY1P7mmL4BkjQ0SqUpf1snw==",
+      "version": "18.2.8",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@types/react-dom/-/react-dom-18.2.8.tgz",
+      "integrity": "sha512-bAIvO5lN/U8sPGvs1Xm61rlRHHaq5rp5N3kp9C+NJ/Q41P8iqjkXSu0+/qu8POsjH9pNWb0OYabFez7taP7omw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1585,22 +1604,23 @@
       }
     },
     "node_modules/@types/scheduler": {
-      "version": "0.16.3",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@types/scheduler/-/scheduler-0.16.3.tgz",
-      "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==",
+      "version": "0.16.4",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@types/scheduler/-/scheduler-0.16.4.tgz",
+      "integrity": "sha512-2L9ifAGl7wmXwP4v3pN4p2FLhD0O1qsJpvKmNin5VA8+UvNVb447UDaAEV6UdrkA+m/Xs58U1RFps44x6TFsVQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "4.0.0",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@vitejs/plugin-react/-/plugin-react-4.0.0.tgz",
-      "integrity": "sha512-HX0XzMjL3hhOYm+0s95pb0Z7F8O81G7joUHgfDd/9J/ZZf5k4xX6QAMFkKsHFxaHlf6X7GD7+XuaZ66ULiJuhQ==",
+      "version": "4.1.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/@vitejs/plugin-react/-/plugin-react-4.1.0.tgz",
+      "integrity": "sha512-rM0SqazU9iqPUraQ2JlIvReeaxOoRj6n+PzB1C0cBzIbd8qP336nC39/R9yPi3wVcah7E7j/kdU1uCUqMEU4OQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.21.4",
-        "@babel/plugin-transform-react-jsx-self": "^7.21.0",
-        "@babel/plugin-transform-react-jsx-source": "^7.19.6",
+        "@babel/core": "^7.22.20",
+        "@babel/plugin-transform-react-jsx-self": "^7.22.5",
+        "@babel/plugin-transform-react-jsx-source": "^7.22.5",
+        "@types/babel__core": "^7.20.2",
         "react-refresh": "^0.14.0"
       },
       "engines": {
@@ -1611,9 +1631,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.8.2",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/acorn/-/acorn-8.8.2.tgz",
-      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+      "version": "8.10.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/acorn/-/acorn-8.10.0.tgz",
+      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1699,16 +1719,16 @@
       }
     },
     "node_modules/array-includes": {
-      "version": "3.1.6",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/array-includes/-/array-includes-3.1.6.tgz",
-      "integrity": "sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==",
+      "version": "3.1.7",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/array-includes/-/array-includes-3.1.7.tgz",
+      "integrity": "sha512-dlcsNBIiWhPkHdOEEKnehA+RNUWDc4UqFtnIXU4uuYDPtA4LDkr7qip2p0VvFAEXNDr0yWZ9PJyIRiGjRLQzwQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4",
-        "get-intrinsic": "^1.1.3",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
+        "get-intrinsic": "^1.2.1",
         "is-string": "^1.0.7"
       },
       "engines": {
@@ -1718,16 +1738,35 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/array.prototype.flatmap": {
-      "version": "1.3.1",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/array.prototype.flatmap/-/array.prototype.flatmap-1.3.1.tgz",
-      "integrity": "sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==",
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.2",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/array.prototype.flat/-/array.prototype.flat-1.3.2.tgz",
+      "integrity": "sha512-djYB+Zx2vLewY8RWlNCUdHjDXs2XOgm602S9E7P/UpHgfeHL00cRiIF+IN/G/aUJ7kGPb6yO/ErDI5V2s8iycA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
+        "es-shim-unscopables": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.2",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/array.prototype.flatmap/-/array.prototype.flatmap-1.3.2.tgz",
+      "integrity": "sha512-Ewyx0c9PmpcsByhSW4r+9zDU7sGjFc86qf/kKtuSCRdhfbk0SNLLkaT5qvcHnRGgc5NP/ly/y+qkXkqONX54CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
         "es-shim-unscopables": "^1.0.0"
       },
       "engines": {
@@ -1738,17 +1777,49 @@
       }
     },
     "node_modules/array.prototype.tosorted": {
-      "version": "1.1.1",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/array.prototype.tosorted/-/array.prototype.tosorted-1.1.1.tgz",
-      "integrity": "sha512-pZYPXPRl2PqWcsUs6LOMn+1f1532nEoPTYowBtqLwAW+W8vSVhkIGnmOX1t/UQjD6YGI0vcD2B1U7ZFGQH9jnQ==",
+      "version": "1.1.2",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/array.prototype.tosorted/-/array.prototype.tosorted-1.1.2.tgz",
+      "integrity": "sha512-HuQCHOlk1Weat5jzStICBCd83NxiIMwqDg/dHEsoefabn/hJRj5pVdWcPUSpRrwhwxZOsQassMpgN/xRYFBMIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
         "es-shim-unscopables": "^1.0.0",
-        "get-intrinsic": "^1.1.3"
+        "get-intrinsic": "^1.2.1"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.2",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.2.tgz",
+      "integrity": "sha512-yMBKppFur/fbHu9/6USUe03bZ4knMYiwFBcyiaXB8Go0qNehwX6inYPzK9U0NeQvGxKthcmHcaR8P5MStSRBAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.0",
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
+        "get-intrinsic": "^1.2.1",
+        "is-array-buffer": "^3.0.2",
+        "is-shared-array-buffer": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/asynciterator.prototype": {
+      "version": "1.0.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/asynciterator.prototype/-/asynciterator.prototype-1.0.0.tgz",
+      "integrity": "sha512-wwHYEIS0Q80f5mosx3L/dfG5t5rjEa9Ft51GTaNt862EnpyGHpgz2RkZvLPp1oF5TnAiTohkEKVEu8pQPJI7Vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
       }
     },
     "node_modules/available-typed-arrays": {
@@ -1783,9 +1854,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.7",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/browserslist/-/browserslist-4.21.7.tgz",
-      "integrity": "sha512-BauCXrQ7I2ftSqd2mvKHGo85XR0u7Ru3C/Hxsy/0TkfCtjrmAbPdzLGasmoiBxplpDXlPvdjX9u7srIMfgasNA==",
+      "version": "4.22.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/browserslist/-/browserslist-4.22.0.tgz",
+      "integrity": "sha512-v+Jcv64L2LbfTC6OnRcaxtqJNJuQAVhZKSJfR/6hn7lhnChUXl4amwVviqN1k411BB+3rRoKMitELRn1CojeRA==",
       "funding": [
         {
           "type": "opencollective",
@@ -1802,10 +1873,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001489",
-        "electron-to-chromium": "^1.4.411",
-        "node-releases": "^2.0.12",
-        "update-browserslist-db": "^1.0.11"
+        "caniuse-lite": "^1.0.30001539",
+        "electron-to-chromium": "^1.4.530",
+        "node-releases": "^2.0.13",
+        "update-browserslist-db": "^1.0.13"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1850,9 +1921,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001492",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/caniuse-lite/-/caniuse-lite-1.0.30001492.tgz",
-      "integrity": "sha512-2efF8SAZwgAX1FJr87KWhvuJxnGJKOnctQa8xLOskAXNXq8oiuqgl6u1kk3fFpsp3GgvzlRjiK1sl63hNtFADw==",
+      "version": "1.0.30001541",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/caniuse-lite/-/caniuse-lite-1.0.30001541.tgz",
+      "integrity": "sha512-bLOsqxDgTqUBkzxbNlSBt8annkDpQB9NdzdTbO2ooJ+eC/IQcvDspDc058g84ejCelF7vHUx57KIOjEecOHXaw==",
       "funding": [
         {
           "type": "opencollective",
@@ -1889,15 +1960,6 @@
       "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==",
       "license": "MIT"
     },
-    "node_modules/clsx": {
-      "version": "1.2.1",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/color-convert/-/color-convert-1.9.3.tgz",
@@ -1927,9 +1989,9 @@
       "license": "MIT"
     },
     "node_modules/convert-source-map": {
-      "version": "1.9.0",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/convert-source-map/-/convert-source-map-1.9.0.tgz",
-      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "version": "2.0.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "license": "MIT"
     },
     "node_modules/copy-anything": {
@@ -1945,14 +2007,14 @@
       }
     },
     "node_modules/cosmiconfig": {
-      "version": "8.1.3",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/cosmiconfig/-/cosmiconfig-8.1.3.tgz",
-      "integrity": "sha512-/UkO2JKI18b5jVMJUp0lvKFMpa/Gye+ZgZjKD+DGEN9y7NRcf/nK1A0sp67ONmKtnDCNMS44E6jrk0Yc3bDuUw==",
+      "version": "8.3.6",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+      "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
       "license": "MIT",
       "dependencies": {
-        "import-fresh": "^3.2.1",
+        "import-fresh": "^3.3.0",
         "js-yaml": "^4.1.0",
-        "parse-json": "^5.0.0",
+        "parse-json": "^5.2.0",
         "path-type": "^4.0.0"
       },
       "engines": {
@@ -1960,6 +2022,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/cross-spawn": {
@@ -1981,6 +2051,7 @@
       "version": "3.1.2",
       "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/csstype/-/csstype-3.1.2.tgz",
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -2007,13 +2078,29 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/define-properties": {
-      "version": "1.2.0",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/define-properties/-/define-properties-1.2.0.tgz",
-      "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
+    "node_modules/define-data-property": {
+      "version": "1.1.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/define-data-property/-/define-data-property-1.1.0.tgz",
+      "integrity": "sha512-UzGwzcjyv3OtAvolTj1GoyNYzfFR+iqbGjcnBEENZVCpM4/Ng1yhGNvS3lR/xDS74Tb2wGG9WzNSNIOS9UVb2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "get-intrinsic": "^1.2.1",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
       },
@@ -2048,20 +2135,20 @@
         "to-camel-case": "1.0.0"
       }
     },
-    "node_modules/dom-helpers": {
-      "version": "5.2.1",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/dom-helpers/-/dom-helpers-5.2.1.tgz",
-      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+    "node_modules/dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.8.7",
-        "csstype": "^3.0.2"
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.416",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/electron-to-chromium/-/electron-to-chromium-1.4.416.tgz",
-      "integrity": "sha512-AUYh0XDTb2vrj0rj82jb3P9hHSyzQNdTPYWZIhPdCOui7/vpme7+HTE07BE5jwuqg/34TZ8ktlRz6GImJ4IXjA==",
+      "version": "1.4.532",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/electron-to-chromium/-/electron-to-chromium-1.4.532.tgz",
+      "integrity": "sha512-piIR0QFdIGKmOJTSNg5AwxZRNWQSXlRYycqDB9Srstx4lip8KpcmRxVP6zuFWExWziHYZpJ0acX7TxqX95KBpg==",
       "license": "ISC"
     },
     "node_modules/entities": {
@@ -2099,19 +2186,20 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.21.2",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/es-abstract/-/es-abstract-1.21.2.tgz",
-      "integrity": "sha512-y/B5POM2iBnIxCiernH1G7rC9qQoM77lLIMQLuob0zhp8C56Po81+2Nj0WFKnd0pNReDTnkYryc+zhOzpEIROg==",
+      "version": "1.22.2",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/es-abstract/-/es-abstract-1.22.2.tgz",
+      "integrity": "sha512-YoxfFcDmhjOgWPWsV13+2RNjq1F6UQnfs+8TftwNqtzlmFzEXvlUwdrNrYeaizfjQzRMxkZ6ElWMOJIFKdVqwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "array-buffer-byte-length": "^1.0.0",
+        "arraybuffer.prototype.slice": "^1.0.2",
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
         "es-set-tostringtag": "^2.0.1",
         "es-to-primitive": "^1.2.1",
-        "function.prototype.name": "^1.1.5",
-        "get-intrinsic": "^1.2.0",
+        "function.prototype.name": "^1.1.6",
+        "get-intrinsic": "^1.2.1",
         "get-symbol-description": "^1.0.0",
         "globalthis": "^1.0.3",
         "gopd": "^1.0.1",
@@ -2126,25 +2214,52 @@
         "is-regex": "^1.1.4",
         "is-shared-array-buffer": "^1.0.2",
         "is-string": "^1.0.7",
-        "is-typed-array": "^1.1.10",
+        "is-typed-array": "^1.1.12",
         "is-weakref": "^1.0.2",
         "object-inspect": "^1.12.3",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.4.3",
+        "regexp.prototype.flags": "^1.5.1",
+        "safe-array-concat": "^1.0.1",
         "safe-regex-test": "^1.0.0",
-        "string.prototype.trim": "^1.2.7",
-        "string.prototype.trimend": "^1.0.6",
-        "string.prototype.trimstart": "^1.0.6",
+        "string.prototype.trim": "^1.2.8",
+        "string.prototype.trimend": "^1.0.7",
+        "string.prototype.trimstart": "^1.0.7",
+        "typed-array-buffer": "^1.0.0",
+        "typed-array-byte-length": "^1.0.0",
+        "typed-array-byte-offset": "^1.0.0",
         "typed-array-length": "^1.0.4",
         "unbox-primitive": "^1.0.2",
-        "which-typed-array": "^1.1.9"
+        "which-typed-array": "^1.1.11"
       },
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-iterator-helpers": {
+      "version": "1.0.15",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/es-iterator-helpers/-/es-iterator-helpers-1.0.15.tgz",
+      "integrity": "sha512-GhoY8uYqd6iwUl2kgjTm4CZAf6oo5mHK7BPqx3rKgx893YSsy0LGHV6gfqqQvZt/8xM8xeOnfXBCfqclMKkJ5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynciterator.prototype": "^1.0.0",
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.22.1",
+        "es-set-tostringtag": "^2.0.1",
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.2.1",
+        "globalthis": "^1.0.3",
+        "has-property-descriptors": "^1.0.0",
+        "has-proto": "^1.0.1",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.5",
+        "iterator.prototype": "^1.1.2",
+        "safe-array-concat": "^1.0.1"
       }
     },
     "node_modules/es-set-tostringtag": {
@@ -2191,9 +2306,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.17.19",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/esbuild/-/esbuild-0.17.19.tgz",
-      "integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
+      "version": "0.18.20",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/esbuild/-/esbuild-0.18.20.tgz",
+      "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -2203,28 +2318,28 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/android-arm": "0.17.19",
-        "@esbuild/android-arm64": "0.17.19",
-        "@esbuild/android-x64": "0.17.19",
-        "@esbuild/darwin-arm64": "0.17.19",
-        "@esbuild/darwin-x64": "0.17.19",
-        "@esbuild/freebsd-arm64": "0.17.19",
-        "@esbuild/freebsd-x64": "0.17.19",
-        "@esbuild/linux-arm": "0.17.19",
-        "@esbuild/linux-arm64": "0.17.19",
-        "@esbuild/linux-ia32": "0.17.19",
-        "@esbuild/linux-loong64": "0.17.19",
-        "@esbuild/linux-mips64el": "0.17.19",
-        "@esbuild/linux-ppc64": "0.17.19",
-        "@esbuild/linux-riscv64": "0.17.19",
-        "@esbuild/linux-s390x": "0.17.19",
-        "@esbuild/linux-x64": "0.17.19",
-        "@esbuild/netbsd-x64": "0.17.19",
-        "@esbuild/openbsd-x64": "0.17.19",
-        "@esbuild/sunos-x64": "0.17.19",
-        "@esbuild/win32-arm64": "0.17.19",
-        "@esbuild/win32-ia32": "0.17.19",
-        "@esbuild/win32-x64": "0.17.19"
+        "@esbuild/android-arm": "0.18.20",
+        "@esbuild/android-arm64": "0.18.20",
+        "@esbuild/android-x64": "0.18.20",
+        "@esbuild/darwin-arm64": "0.18.20",
+        "@esbuild/darwin-x64": "0.18.20",
+        "@esbuild/freebsd-arm64": "0.18.20",
+        "@esbuild/freebsd-x64": "0.18.20",
+        "@esbuild/linux-arm": "0.18.20",
+        "@esbuild/linux-arm64": "0.18.20",
+        "@esbuild/linux-ia32": "0.18.20",
+        "@esbuild/linux-loong64": "0.18.20",
+        "@esbuild/linux-mips64el": "0.18.20",
+        "@esbuild/linux-ppc64": "0.18.20",
+        "@esbuild/linux-riscv64": "0.18.20",
+        "@esbuild/linux-s390x": "0.18.20",
+        "@esbuild/linux-x64": "0.18.20",
+        "@esbuild/netbsd-x64": "0.18.20",
+        "@esbuild/openbsd-x64": "0.18.20",
+        "@esbuild/sunos-x64": "0.18.20",
+        "@esbuild/win32-arm64": "0.18.20",
+        "@esbuild/win32-ia32": "0.18.20",
+        "@esbuild/win32-x64": "0.18.20"
       }
     },
     "node_modules/escalade": {
@@ -2246,28 +2361,28 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.41.0",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/eslint/-/eslint-8.41.0.tgz",
-      "integrity": "sha512-WQDQpzGBOP5IrXPo4Hc0814r4/v2rrIsB0rhT7jtunIalgg6gYXWhRMOejVO8yH21T/FGaxjmFjBMNqcIlmH1Q==",
+      "version": "8.50.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/eslint/-/eslint-8.50.0.tgz",
+      "integrity": "sha512-FOnOGSuFuFLv/Sa+FDVRZl4GGVAAFFi8LecRsI5a1tMO5HIE8nCm4ivAlzt4dT3ol/PaaGC0rJEEXQmHJBGoOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
-        "@eslint-community/regexpp": "^4.4.0",
-        "@eslint/eslintrc": "^2.0.3",
-        "@eslint/js": "8.41.0",
-        "@humanwhocodes/config-array": "^0.11.8",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.2",
+        "@eslint/js": "8.50.0",
+        "@humanwhocodes/config-array": "^0.11.11",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
-        "ajv": "^6.10.0",
+        "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
         "debug": "^4.3.2",
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.2.0",
-        "eslint-visitor-keys": "^3.4.1",
-        "espree": "^9.5.2",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
         "esquery": "^1.4.2",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -2277,7 +2392,6 @@
         "globals": "^13.19.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.0",
-        "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "is-path-inside": "^3.0.3",
@@ -2287,9 +2401,8 @@
         "lodash.merge": "^4.6.2",
         "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.9.1",
+        "optionator": "^0.9.3",
         "strip-ansi": "^6.0.1",
-        "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0"
       },
       "bin": {
@@ -2303,9 +2416,9 @@
       }
     },
     "node_modules/eslint-plugin-react": {
-      "version": "7.32.2",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/eslint-plugin-react/-/eslint-plugin-react-7.32.2.tgz",
-      "integrity": "sha512-t2fBMa+XzonrrNkyVirzKlvn5RXzzPwRHtMvLAtVZrt8oxgnTQaYbU6SXTOO1mwQgp1y5+toMSKInnzGr0Knqg==",
+      "version": "7.33.2",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/eslint-plugin-react/-/eslint-plugin-react-7.33.2.tgz",
+      "integrity": "sha512-73QQMKALArI8/7xGLNI/3LylrEYrlKZSb5C9+q3OtOewTnMQi5cT+aE9E41sLCmli3I9PGGmD1yiZydyo4FEPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2313,6 +2426,7 @@
         "array.prototype.flatmap": "^1.3.1",
         "array.prototype.tosorted": "^1.1.1",
         "doctrine": "^2.1.0",
+        "es-iterator-helpers": "^1.0.12",
         "estraverse": "^5.3.0",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.1.2",
@@ -2322,7 +2436,7 @@
         "object.values": "^1.1.6",
         "prop-types": "^15.8.1",
         "resolve": "^2.0.0-next.4",
-        "semver": "^6.3.0",
+        "semver": "^6.3.1",
         "string.prototype.matchall": "^4.0.8"
       },
       "engines": {
@@ -2346,9 +2460,9 @@
       }
     },
     "node_modules/eslint-plugin-react-refresh": {
-      "version": "0.3.5",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.3.5.tgz",
-      "integrity": "sha512-61qNIsc7fo9Pp/mju0J83kzvLm0Bsayu7OQSLEoJxLDCBjIIyb87bkzufoOvdDxLkSlMfkF7UxomC4+eztUBSA==",
+      "version": "0.4.3",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.3.tgz",
+      "integrity": "sha512-Hh0wv8bUNY877+sI0BlCUlsS0TYYQqvzEwJsJJPM2WF4RnTStSnSR3zdJYa2nPOJgg3UghXi54lVyMSmpCalzA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -2369,9 +2483,9 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "7.2.0",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/eslint-scope/-/eslint-scope-7.2.0.tgz",
-      "integrity": "sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==",
+      "version": "7.2.2",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -2386,9 +2500,9 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.4.1",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
-      "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
+      "version": "3.4.3",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -2465,9 +2579,9 @@
       }
     },
     "node_modules/eslint/node_modules/globals": {
-      "version": "13.20.0",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/globals/-/globals-13.20.0.tgz",
-      "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+      "version": "13.22.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/globals/-/globals-13.22.0.tgz",
+      "integrity": "sha512-H1Ddc/PbZHTDVJSnj8kWptIRSD6AM3pK+mKytuIVF4uoBV7rshFlhhvA58ceJ5wp3Er58w6zj7bykMpYXt3ETw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2504,13 +2618,13 @@
       }
     },
     "node_modules/espree": {
-      "version": "9.5.2",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/espree/-/espree-9.5.2.tgz",
-      "integrity": "sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==",
+      "version": "9.6.1",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.8.0",
+        "acorn": "^8.9.0",
         "acorn-jsx": "^5.3.2",
         "eslint-visitor-keys": "^3.4.1"
       },
@@ -2635,23 +2749,24 @@
       }
     },
     "node_modules/flat-cache": {
-      "version": "3.0.4",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/flat-cache/-/flat-cache-3.0.4.tgz",
-      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "version": "3.1.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/flat-cache/-/flat-cache-3.1.0.tgz",
+      "integrity": "sha512-OHx4Qwrrt0E4jEIcI5/Xb+f+QmJYNj2rrK8wiIdQOIrB9WrrJL8cjZvXdXuBTkkEwEqLycb5BeZDV1o2i9bTew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "flatted": "^3.1.0",
+        "flatted": "^3.2.7",
+        "keyv": "^4.5.3",
         "rimraf": "^3.0.2"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/flatted": {
-      "version": "3.2.7",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/flatted/-/flatted-3.2.7.tgz",
-      "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
+      "version": "3.2.9",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/flatted/-/flatted-3.2.9.tgz",
+      "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -2665,13 +2780,6 @@
         "is-callable": "^1.1.3"
       }
     },
-    "node_modules/fs": {
-      "version": "0.0.1-security",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/fs/-/fs-0.0.1-security.tgz",
-      "integrity": "sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2680,9 +2788,9 @@
       "license": "ISC"
     },
     "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "version": "2.3.3",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2701,16 +2809,16 @@
       "license": "MIT"
     },
     "node_modules/function.prototype.name": {
-      "version": "1.1.5",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
-      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+      "version": "1.1.6",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
+      "integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.0",
-        "functions-have-names": "^1.2.2"
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
+        "functions-have-names": "^1.2.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3060,6 +3168,22 @@
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "license": "MIT"
     },
+    "node_modules/is-async-function": {
+      "version": "2.0.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/is-async-function/-/is-async-function-2.0.0.tgz",
+      "integrity": "sha512-Y1JXKrfykRJGdlDwdKlLpLyMIiWqWvuSd17TvZk68PLAOGOoF4Xyav1z0Xhoi+gCYjZVeC5SI+hYFOfvXmGRCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-bigint": {
       "version": "1.0.4",
       "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/is-bigint/-/is-bigint-1.0.4.tgz",
@@ -3104,9 +3228,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.12.1",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/is-core-module/-/is-core-module-2.12.1.tgz",
-      "integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
+      "version": "2.13.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/is-core-module/-/is-core-module-2.13.0.tgz",
+      "integrity": "sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3142,6 +3266,35 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.0.2",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/is-finalizationregistry/-/is-finalizationregistry-1.0.2.tgz",
+      "integrity": "sha512-0by5vtUJs8iFQb5TYUHHPudOR+qXYIMKtiUzvLIZITZUjknFmziyBJuLhVRc+Ds0dREFlskDNJKYIdIzu/9pfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.0.10",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/is-generator-function/-/is-generator-function-1.0.10.tgz",
+      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/is-glob/-/is-glob-4.0.3.tgz",
@@ -3153,6 +3306,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-map": {
+      "version": "2.0.2",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/is-map/-/is-map-2.0.2.tgz",
+      "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-negative-zero": {
@@ -3211,6 +3374,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-set": {
+      "version": "2.0.2",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/is-set/-/is-set-2.0.2.tgz",
+      "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-shared-array-buffer": {
       "version": "1.0.2",
       "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
@@ -3257,21 +3430,27 @@
       }
     },
     "node_modules/is-typed-array": {
-      "version": "1.1.10",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/is-typed-array/-/is-typed-array-1.1.10.tgz",
-      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+      "version": "1.1.12",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/is-typed-array/-/is-typed-array-1.1.12.tgz",
+      "integrity": "sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
-        "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "has-tostringtag": "^1.0.0"
+        "which-typed-array": "^1.1.11"
       },
       "engines": {
         "node": ">= 0.4"
       },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.1",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/is-weakmap/-/is-weakmap-2.0.1.tgz",
+      "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==",
+      "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -3289,10 +3468,31 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-weakset": {
+      "version": "2.0.2",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/is-weakset/-/is-weakset-2.0.2.tgz",
+      "integrity": "sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-what": {
       "version": "3.14.1",
       "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/is-what/-/is-what-3.14.1.tgz",
       "integrity": "sha512-sNxgpk9793nzSs7bA6JQJGeIuRBQhAaNGG77kzYQgMkrID+lS6SlK07K5LaptscDlSaIgH+GPFzf+d75FVxozA==",
+      "license": "MIT"
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -3301,6 +3501,20 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/iterator.prototype": {
+      "version": "1.1.2",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/iterator.prototype/-/iterator.prototype-1.1.2.tgz",
+      "integrity": "sha512-DR33HMMr8EzwuRL8Y9D3u2BMj8+RqSE850jfGu59kS7tbmPLzGkZmVSfyCFSDxuZiEY6Rzt3T2NA/qU+NwVj1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "get-intrinsic": "^1.2.1",
+        "has-symbols": "^1.0.3",
+        "reflect.getprototypeof": "^1.0.4",
+        "set-function-name": "^2.0.1"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -3331,6 +3545,13 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
@@ -3365,23 +3586,35 @@
       }
     },
     "node_modules/jsx-ast-utils": {
-      "version": "3.3.3",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz",
-      "integrity": "sha512-fYQHZTZ8jSfmWZ0iyzfwiU4WDX4HpHbMCZ3gPlWYiCl3BoeOTsqKBqnTVfH2rYT7eP5c3sVbeSPHnnJOaTrWiw==",
+      "version": "3.3.5",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+      "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "array-includes": "^3.1.5",
-        "object.assign": "^4.1.3"
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "object.assign": "^4.1.4",
+        "object.values": "^1.1.6"
       },
       "engines": {
         "node": ">=4.0"
       }
     },
+    "node_modules/keyv": {
+      "version": "4.5.3",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/keyv/-/keyv-4.5.3.tgz",
+      "integrity": "sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "node_modules/less": {
-      "version": "4.1.3",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/less/-/less-4.1.3.tgz",
-      "integrity": "sha512-w16Xk/Ta9Hhyei0Gpz9m7VS8F28nieJaL/VyShID7cYvP6IL5oHeL6p4TXSDJqZE/lNv0oJ2pGVjJsRkfwm5FA==",
+      "version": "4.2.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/less/-/less-4.2.0.tgz",
+      "integrity": "sha512-P3b3HJDBtSzsXUl0im2L7gTO5Ubg8mEN6G8qoTS77iXxXX4Hvu4Qj540PZDvQ8V6DmX6iXo98k7Md0Cm1PrLaA==",
       "license": "Apache-2.0",
       "dependencies": {
         "copy-anything": "^2.0.1",
@@ -3471,6 +3704,15 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3495,9 +3737,9 @@
       }
     },
     "node_modules/make-dir/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "license": "ISC",
       "optional": true,
       "bin": {
@@ -3595,10 +3837,20 @@
         "ms": "^2.1.1"
       }
     },
+    "node_modules/no-case": {
+      "version": "3.0.4",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "license": "MIT",
+      "dependencies": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/node-releases": {
-      "version": "2.0.12",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/node-releases/-/node-releases-2.0.12.tgz",
-      "integrity": "sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ==",
+      "version": "2.0.13",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/node-releases/-/node-releases-2.0.13.tgz",
+      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
       "license": "MIT"
     },
     "node_modules/object-assign": {
@@ -3650,30 +3902,30 @@
       }
     },
     "node_modules/object.entries": {
-      "version": "1.1.6",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/object.entries/-/object.entries-1.1.6.tgz",
-      "integrity": "sha512-leTPzo4Zvg3pmbQ3rDK69Rl8GQvIqMWubrkxONG9/ojtFE2rD9fjMKfSI5BxW3osRH1m6VdzmqK8oAY9aT4x5w==",
+      "version": "1.1.7",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/object.entries/-/object.entries-1.1.7.tgz",
+      "integrity": "sha512-jCBs/0plmPsOnrKAfFQXRG2NFjlhZgjjcBLSmTnEhU8U6vVTsVe8ANeQJCHTl3gSsI4J+0emOoCgoKlmQPMgmA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1"
       },
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/object.fromentries": {
-      "version": "2.0.6",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/object.fromentries/-/object.fromentries-2.0.6.tgz",
-      "integrity": "sha512-VciD13dswC4j1Xt5394WR4MzmAQmlgN72phd/riNp9vtD7tp4QQWJ0R4wvclXcafgcYK8veHRed2W6XeGBvcfg==",
+      "version": "2.0.7",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/object.fromentries/-/object.fromentries-2.0.7.tgz",
+      "integrity": "sha512-UPbPHML6sL8PI/mOqPwsH4G6iyXcCGzLin8KvEPenOZN5lpCNBZZQ+V62vdjB1mQHrmqGQt5/OJzemUA+KJmEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3683,29 +3935,29 @@
       }
     },
     "node_modules/object.hasown": {
-      "version": "1.1.2",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/object.hasown/-/object.hasown-1.1.2.tgz",
-      "integrity": "sha512-B5UIT3J1W+WuWIU55h0mjlwaqxiE5vYENJXIXZ4VFe05pNYrkKuK0U/6aFcb0pKywYJh7IhfoqUfKVmrJJHZHw==",
+      "version": "1.1.3",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/object.hasown/-/object.hasown-1.1.3.tgz",
+      "integrity": "sha512-fFI4VcYpRHvSLXxP7yiZOMAd331cPfd2p7PFDVbgUsYOfCT3tICVqXWngbjr4m49OvsBwUBQ6O2uQoJvy3RexA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object.values": {
-      "version": "1.1.6",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/object.values/-/object.values-1.1.6.tgz",
-      "integrity": "sha512-FVVTkD1vENCsAcwNs9k6jea2uHC/X0+JcjG8YA60FN5CMaJmG95wT9jek/xX9nornqGRrBkKtzuAu2wuHpKqvw==",
+      "version": "1.1.7",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/object.values/-/object.values-1.1.7.tgz",
+      "integrity": "sha512-aU6xnDFYT3x17e/f0IiiwlGPTy2jzMySGfUB4fq6z7CV8l85CWHDk5ErhyhpfDHhrOMwGFhSQkhMGHaIotA6Ng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3725,18 +3977,18 @@
       }
     },
     "node_modules/optionator": {
-      "version": "0.9.1",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/optionator/-/optionator-0.9.1.tgz",
-      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "version": "0.9.3",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/optionator/-/optionator-0.9.3.tgz",
+      "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@aashutoshrathi/word-wrap": "^1.2.3",
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
         "levn": "^0.4.1",
         "prelude-ls": "^1.2.1",
-        "type-check": "^0.4.0",
-        "word-wrap": "^1.2.3"
+        "type-check": "^0.4.0"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -3811,17 +4063,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/path": {
-      "version": "0.12.7",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/path/-/path-0.12.7.tgz",
-      "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "process": "^0.11.1",
-        "util": "^0.10.3"
       }
     },
     "node_modules/path-exists": {
@@ -3905,9 +4146,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.24",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/postcss/-/postcss-8.4.24.tgz",
-      "integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
+      "version": "8.4.30",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/postcss/-/postcss-8.4.30.tgz",
+      "integrity": "sha512-7ZEao1g4kd68l97aWG/etQKPKq07us0ieSZ2TnFDk11i0ZfDW2AwKHYU8qv4MZKqN2fdBfg+7q0ES06UA73C1g==",
       "funding": [
         {
           "type": "opencollective",
@@ -3949,29 +4190,19 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.0.3",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/prettier/-/prettier-3.0.3.tgz",
+      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
       "dev": true,
       "license": "MIT",
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "node_modules/process": {
-      "version": "0.11.10",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/process/-/process-0.11.10.tgz",
-      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
       }
     },
     "node_modules/prop-types": {
@@ -4087,12 +4318,6 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
-    "node_modules/react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
-      "license": "MIT"
-    },
     "node_modules/react-refresh": {
       "version": "0.14.0",
       "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/react-refresh/-/react-refresh-0.14.0.tgz",
@@ -4104,53 +4329,35 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.11.2",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/react-router/-/react-router-6.11.2.tgz",
-      "integrity": "sha512-74z9xUSaSX07t3LM+pS6Un0T55ibUE/79CzfZpy5wsPDZaea1F8QkrsiyRnA2YQ7LwE/umaydzXZV80iDCPkMg==",
+      "version": "6.16.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/react-router/-/react-router-6.16.0.tgz",
+      "integrity": "sha512-VT4Mmc4jj5YyjpOi5jOf0I+TYzGpvzERy4ckNSvSh2RArv8LLoCxlsZ2D+tc7zgjxcY34oTz2hZaeX5RVprKqA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.6.2"
+        "@remix-run/router": "1.9.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
         "react": ">=16.8"
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.11.2",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/react-router-dom/-/react-router-dom-6.11.2.tgz",
-      "integrity": "sha512-JNbKtAeh1VSJQnH6RvBDNhxNwemRj7KxCzc5jb7zvDSKRnPWIFj9pO+eXqjM69gQJ0r46hSz1x4l9y0651DKWw==",
+      "version": "6.16.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/react-router-dom/-/react-router-dom-6.16.0.tgz",
+      "integrity": "sha512-aTfBLv3mk/gaKLxgRDUPbPw+s4Y/O+ma3rEN1u8EgEpLpPe6gNjIsWt9rxushMHHMb7mSwxRGdGlGdvmFsyPIg==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.6.2",
-        "react-router": "6.11.2"
+        "@remix-run/router": "1.9.0",
+        "react-router": "6.16.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/react-virtualized": {
-      "version": "9.22.5",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/react-virtualized/-/react-virtualized-9.22.5.tgz",
-      "integrity": "sha512-YqQMRzlVANBv1L/7r63OHa2b0ZsAaDp1UhVNEdUaXI8A5u6hTpA5NYtUueLH2rFuY/27mTGIBl7ZhqFKzw18YQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "clsx": "^1.0.4",
-        "dom-helpers": "^5.1.3",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.7.2",
-        "react-lifecycles-compat": "^3.0.4"
-      },
-      "peerDependencies": {
-        "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0",
-        "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-window": {
@@ -4170,22 +4377,43 @@
         "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
-    "node_modules/regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "license": "MIT"
-    },
-    "node_modules/regexp.prototype.flags": {
-      "version": "1.5.0",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz",
-      "integrity": "sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==",
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.4",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/reflect.getprototypeof/-/reflect.getprototypeof-1.0.4.tgz",
+      "integrity": "sha512-ECkTw8TmJwW60lOTR+ZkODISW6RQ8+2CL3COqtiJKLd6MmB45hN51HprHFziKLGkAuTGQhBb91V8cy+KHlaCjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.2.0",
-        "functions-have-names": "^1.2.3"
+        "es-abstract": "^1.22.1",
+        "get-intrinsic": "^1.2.1",
+        "globalthis": "^1.0.3",
+        "which-builtin-type": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==",
+      "license": "MIT"
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.1",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/regexp.prototype.flags/-/regexp.prototype.flags-1.5.1.tgz",
+      "integrity": "sha512-sy6TXMN+hnP/wMy+ISxg3krXx7BAtWVO4UouuCN/ziM9UEne0euamVNafDfvC83bRNr95y0V5iijeDQFUNpvrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.0",
+        "set-function-name": "^2.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4249,9 +4477,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.23.0",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/rollup/-/rollup-3.23.0.tgz",
-      "integrity": "sha512-h31UlwEi7FHihLe1zbk+3Q7z1k/84rb9BSwmBSr/XjOCEaBJ2YyedQDuM0t/kfOS0IxM+vk1/zI9XxYj9V+NJQ==",
+      "version": "3.29.4",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/rollup/-/rollup-3.29.4.tgz",
+      "integrity": "sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==",
       "license": "MIT",
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -4288,6 +4516,25 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-array-concat": {
+      "version": "1.0.1",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/safe-array-concat/-/safe-array-concat-1.0.1.tgz",
+      "integrity": "sha512-6XbUAseYE2KtOuGueyeobCySj9L4+66Tn6KQMOPQJrAJEowYKW/YR/MGJZl7FdydUdaFu4LYyDZjxf4/Nmo23Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.2.1",
+        "has-symbols": "^1.0.3",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/safe-regex-test": {
       "version": "1.0.0",
       "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
@@ -4311,9 +4558,9 @@
       "optional": true
     },
     "node_modules/sax": {
-      "version": "1.2.4",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "version": "1.3.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/sax/-/sax-1.3.0.tgz",
+      "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==",
       "license": "ISC",
       "optional": true
     },
@@ -4327,12 +4574,27 @@
       }
     },
     "node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.1",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/set-function-name/-/set-function-name-2.0.1.tgz",
+      "integrity": "sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/shebang-command": {
@@ -4373,6 +4635,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/snake-case": {
+      "version": "3.0.4",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/snake-case/-/snake-case-3.0.4.tgz",
+      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+      "license": "MIT",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/source-map/-/source-map-0.6.1.tgz",
@@ -4393,25 +4665,26 @@
       }
     },
     "node_modules/sprintf-js": {
-      "version": "1.1.2",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/sprintf-js/-/sprintf-js-1.1.2.tgz",
-      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+      "version": "1.1.3",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
       "license": "BSD-3-Clause"
     },
     "node_modules/string.prototype.matchall": {
-      "version": "4.0.8",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/string.prototype.matchall/-/string.prototype.matchall-4.0.8.tgz",
-      "integrity": "sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==",
+      "version": "4.0.10",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/string.prototype.matchall/-/string.prototype.matchall-4.0.10.tgz",
+      "integrity": "sha512-rGXbGmOEosIQi6Qva94HUjgPs9vKW+dkG7Y8Q5O2OYkWL6wFaTRZO8zM4mhP94uX55wgyrXzfS2aGtGzUL7EJQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4",
-        "get-intrinsic": "^1.1.3",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
+        "get-intrinsic": "^1.2.1",
         "has-symbols": "^1.0.3",
-        "internal-slot": "^1.0.3",
-        "regexp.prototype.flags": "^1.4.3",
+        "internal-slot": "^1.0.5",
+        "regexp.prototype.flags": "^1.5.0",
+        "set-function-name": "^2.0.0",
         "side-channel": "^1.0.4"
       },
       "funding": {
@@ -4419,15 +4692,15 @@
       }
     },
     "node_modules/string.prototype.trim": {
-      "version": "1.2.7",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz",
-      "integrity": "sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==",
+      "version": "1.2.8",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/string.prototype.trim/-/string.prototype.trim-1.2.8.tgz",
+      "integrity": "sha512-lfjY4HcixfQXOfaqCvcBuOIapyaroTXhbkfJN3gcB1OtyupngWK4sEET9Knd0cXd28kTUqu/kHoV4HKSJdnjiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4437,30 +4710,30 @@
       }
     },
     "node_modules/string.prototype.trimend": {
-      "version": "1.0.6",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
-      "integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
+      "version": "1.0.7",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/string.prototype.trimend/-/string.prototype.trimend-1.0.7.tgz",
+      "integrity": "sha512-Ni79DqeB72ZFq1uH/L6zJ+DKZTkOtPIHovb3YZHQViE+HDouuU4mBrLOLDn5Dde3RF8qw5qVETEjhu9locMLvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimstart": {
-      "version": "1.0.6",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
-      "integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
+      "version": "1.0.7",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/string.prototype.trimstart/-/string.prototype.trimstart-1.0.7.tgz",
+      "integrity": "sha512-NGhtDFu3jCEm7B4Fy0DpLewdJQOZcQ0rGbwQ/+stjnrp2i+rlKeCvos9hOIeCmqwratM47OBxY7uFZzjxHXmrg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4564,9 +4837,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.5.2",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/tslib/-/tslib-2.5.2.tgz",
-      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA==",
+      "version": "2.6.2",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
       "license": "0BSD"
     },
     "node_modules/type-check": {
@@ -4593,6 +4866,60 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/typed-array-buffer/-/typed-array-buffer-1.0.0.tgz",
+      "integrity": "sha512-Y8KTSIglk9OZEr8zywiIHG/kmQ7KWyjseXs1CbSo8vC42w7hg2HgYTxSWwP0+is7bWDc1H+Fo026CpHFwm8tkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.2.1",
+        "is-typed-array": "^1.1.10"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/typed-array-byte-length/-/typed-array-byte-length-1.0.0.tgz",
+      "integrity": "sha512-Or/+kvLxNpeQ9DtSydonMxCx+9ZXOswtwJn17SNLvhptaXYDJvkFFP5zbfU/uLmvnBJlI4yrnXRxpdWH/M5tNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "has-proto": "^1.0.1",
+        "is-typed-array": "^1.1.10"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/typed-array-byte-offset/-/typed-array-byte-offset-1.0.0.tgz",
+      "integrity": "sha512-RD97prjEt9EL8YgAgpOkf3O4IF9lhJFr9g0htQkm0rchFp/Vx7LW5Q8fSXXub7BXAODyUQohRMyOc3faCPd0hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "has-proto": "^1.0.1",
+        "is-typed-array": "^1.1.10"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/typed-array-length": {
@@ -4640,9 +4967,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.11",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
-      "integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
+      "version": "1.0.13",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
       "funding": [
         {
           "type": "opencollective",
@@ -4679,47 +5006,34 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/util": {
-      "version": "0.10.4",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/util/-/util-0.10.4.tgz",
-      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "2.0.3"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
-    "node_modules/util/node_modules/inherits": {
-      "version": "2.0.3",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "version": "9.0.1",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vite": {
-      "version": "4.3.9",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/vite/-/vite-4.3.9.tgz",
-      "integrity": "sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==",
+      "version": "4.4.9",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/vite/-/vite-4.4.9.tgz",
+      "integrity": "sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==",
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.17.5",
-        "postcss": "^8.4.23",
-        "rollup": "^3.21.0"
+        "esbuild": "^0.18.10",
+        "postcss": "^8.4.27",
+        "rollup": "^3.27.1"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -4727,12 +5041,16 @@
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
       },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       },
       "peerDependencies": {
         "@types/node": ">= 14",
         "less": "*",
+        "lightningcss": "^1.21.0",
         "sass": "*",
         "stylus": "*",
         "sugarss": "*",
@@ -4743,6 +5061,9 @@
           "optional": true
         },
         "less": {
+          "optional": true
+        },
+        "lightningcss": {
           "optional": true
         },
         "sass": {
@@ -4760,14 +5081,14 @@
       }
     },
     "node_modules/vite-plugin-svgr": {
-      "version": "3.2.0",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/vite-plugin-svgr/-/vite-plugin-svgr-3.2.0.tgz",
-      "integrity": "sha512-Uvq6niTvhqJU6ga78qLKBFJSDvxWhOnyfQSoKpDPMAGxJPo5S3+9hyjExE5YDj6Lpa4uaLkGc1cBgxXov+LjSw==",
+      "version": "4.0.0",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/vite-plugin-svgr/-/vite-plugin-svgr-4.0.0.tgz",
+      "integrity": "sha512-ingW8FEJ4vz9mQumnMDhNysE+YleiaThYmgflhUIVI4iIjVsVA1SswYIKprWVmyFsiIk1DqcwUeTFCnUJA3Vvg==",
       "license": "MIT",
       "dependencies": {
-        "@rollup/pluginutils": "^5.0.2",
-        "@svgr/core": "^7.0.0",
-        "@svgr/plugin-jsx": "^7.0.0"
+        "@rollup/pluginutils": "^5.0.4",
+        "@svgr/core": "^8.1.0",
+        "@svgr/plugin-jsx": "^8.1.0"
       },
       "peerDependencies": {
         "vite": "^2.6.0 || 3 || 4"
@@ -4806,19 +5127,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/which-typed-array": {
-      "version": "1.1.9",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/which-typed-array/-/which-typed-array-1.1.9.tgz",
-      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+    "node_modules/which-builtin-type": {
+      "version": "1.1.3",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/which-builtin-type/-/which-builtin-type-1.1.3.tgz",
+      "integrity": "sha512-YmjsSMDBYsM1CaFiayOVT06+KJeXf0o5M/CAd4o1lTadFAtacTUM49zoYxr/oroopFDfhvN6iEcBxUyc3gvKmw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
-        "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
+        "function.prototype.name": "^1.1.5",
         "has-tostringtag": "^1.0.0",
-        "is-typed-array": "^1.1.10"
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.0.5",
+        "is-finalizationregistry": "^1.0.2",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.1.4",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.9"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4827,14 +5154,40 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+    "node_modules/which-collection": {
+      "version": "1.0.1",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/which-collection/-/which-collection-1.0.1.tgz",
+      "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.1",
+        "is-set": "^2.0.1",
+        "is-weakmap": "^2.0.1",
+        "is-weakset": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.11",
+      "resolved": "https://nexus.intern.sparebank1.no/repository/npmgroup/which-typed-array/-/which-typed-array-1.1.11.tgz",
+      "integrity": "sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0"
+      },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/wrappy": {

--- a/package.json
+++ b/package.json
@@ -11,25 +11,25 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@sb1/ffe-account-selector-react": "^21.3.6",
+    "@sb1/ffe-account-selector-react": "^22.1.0",
     "@sb1/ffe-buttons": "^17.0.3",
     "@sb1/ffe-buttons-react": "^18.0.2",
-    "@sb1/ffe-cards": "^15.0.3",
-    "@sb1/ffe-cards-react": "^11.0.2",
+    "@sb1/ffe-cards": "^16.2.0",
+    "@sb1/ffe-cards-react": "^12.1.2",
     "@sb1/ffe-chart-donut-react": "^5.2.0",
     "@sb1/ffe-core": "^27.0.1",
     "@sb1/ffe-core-react": "^7.1.1",
     "@sb1/ffe-datepicker": "^11.0.9",
     "@sb1/ffe-datepicker-react": "^6.0.10",
-    "@sb1/ffe-form": "^23.0.7",
-    "@sb1/ffe-form-react": "^11.0.10",
+    "@sb1/ffe-form": "^24.1.0",
+    "@sb1/ffe-form-react": "^13.0.3",
     "@sb1/ffe-formatters": "^4.0.11",
     "@sb1/ffe-grid-react": "^13.0.5",
     "@sb1/ffe-header": "^19.0.2",
     "@sb1/ffe-icons-react": "^7.3.5",
     "@sb1/ffe-message-box": "^11.0.4",
-    "@sb1/ffe-message-box-react": "^8.0.7",
-    "@sb1/ffe-searchable-dropdown-react": "^15.2.3",
+    "@sb1/ffe-message-box-react": "^9.0.3",
+    "@sb1/ffe-searchable-dropdown-react": "^16.1.0",
     "@sb1/ffe-spinner": "^5.0.4",
     "@sb1/ffe-spinner-react": "^6.0.5",
     "@sb1/ffe-tabs": "^13.0.3",
@@ -40,7 +40,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.11.2",
-    "vite-plugin-svgr": "^3.2.0"
+    "vite-plugin-svgr": "^4.0.0"
   },
   "devDependencies": {
     "@types/react": "^18.0.37",
@@ -49,10 +49,8 @@
     "eslint": "^8.38.0",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "eslint-plugin-react-refresh": "^0.3.4",
-    "fs": "^0.0.1-security",
-    "path": "^0.12.7",
-    "prettier": "^2.8.8",
+    "eslint-plugin-react-refresh": "^0.4.3",
+    "prettier": "^3.0.3",
     "vite": "^4.3.9"
   }
 }

--- a/src/.secret/features/oversikt/MinOkonomi/minokonomi.css
+++ b/src/.secret/features/oversikt/MinOkonomi/minokonomi.css
@@ -18,7 +18,12 @@
   background-image: linear-gradient(#4d689f, #4d689f),
     linear-gradient(#dc8000, #dc8000), linear-gradient(#873953, #873953),
     linear-gradient(#ee8d9c, #ee8d9c), linear-gradient(#f8b181, #f8b181);
-  background-size: 55% 100%, 75% 100%, 90% 100%, 95% 100%, 100% 100%;
+  background-size:
+    55% 100%,
+    75% 100%,
+    90% 100%,
+    95% 100%,
+    100% 100%;
   background-repeat: no-repeat;
 }
 

--- a/src/features/oversikt/MinOkonomi/minokonomi.css
+++ b/src/features/oversikt/MinOkonomi/minokonomi.css
@@ -18,7 +18,12 @@
   background-image: linear-gradient(#4d689f, #4d689f),
     linear-gradient(#dc8000, #dc8000), linear-gradient(#873953, #873953),
     linear-gradient(#ee8d9c, #ee8d9c), linear-gradient(#f8b181, #f8b181);
-  background-size: 55% 100%, 75% 100%, 90% 100%, 95% 100%, 100% 100%;
+  background-size:
+    55% 100%,
+    75% 100%,
+    90% 100%,
+    95% 100%,
+    100% 100%;
   background-repeat: no-repeat;
 }
 

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -18,5 +18,5 @@ root.render(
         <Route path="/slik-skal-det-se-ut" element={<SlikSkalDetSeUt />} />
       </Routes>
     </BrowserRouter>
-  </div>
+  </div>,
 );

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,40 +1,12 @@
 import { defineConfig } from 'vite'
 import svgr from 'vite-plugin-svgr'
 import react from '@vitejs/plugin-react'
-import fs from "fs";
-import path from "path";
-import { createRequire } from 'node:module'
-import url from 'node:url'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), svgr() , reactVirtualized()],
+  plugins: [react(), svgr()],
   build: {
     outDir: './public/'
   }
 })
 
-const WRONG_CODE = `import { bpfrpt_proptype_WindowScroller } from "../WindowScroller.js";`;
-function reactVirtualized() {
-  return {
-    name: 'flat:react-virtualized',
-    // Note: we cannot use the `transform` hook here
-    //       because libraries are pre-bundled in vite directly,
-    //       plugins aren't able to hack that step currently.
-    //       so instead we manually edit the file in node_modules.
-    //       all we need is to find the timing before pre-bundling.
-    configResolved: async () => {
-      const require = createRequire(import.meta.url)
-      const reactVirtualizedPath = require.resolve('react-virtualized')
-      const { pathname: reactVirtualizedFilePath } = new url.URL(reactVirtualizedPath, import.meta.url)
-      const file = reactVirtualizedFilePath
-          .replace(
-              path.join('dist', 'commonjs', 'index.js'),
-              path.join('dist', 'es', 'WindowScroller', 'utils', 'onScroll.js'),
-          )
-      const code = fs.readFileSync(file, "utf-8");
-      const modified = code.replace(WRONG_CODE, "");
-      fs.writeFileSync(file, modified);
-    },
-  }
-}


### PR DESCRIPTION
Så at [trøbbelet med ffe-account-selector nå er fikset](https://github.com/SpareBank1/designsystem/pull/1670) :tada: så har bumpet den, samt noen andre avhengigheter vi hadde som var litt utdaterte og slettet workaround-koden.
Kjørte også prettier. Var ikke så mye der, så la inn det lille som var i samme commit. 

Så ikke ut til å være noen visuelle endringer som følge av bumpingen, men ta gjerne en kikk selv om dere vil :slightly_smiling_face: 